### PR TITLE
Support Avalanche C-Chain Fuji in the blockchain credential

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -23,11 +23,11 @@ TWITTER_REDIRECT_URI=
 TWITTER_CLIENT_ID=
 TWITTER_CLIENT_SECRET=
 
-# The network name must be the same as what appears in the `blockchainCredentialSupportedNetworks` list 
-# exported from the `@bandada/utils` package but with capital letters and an underscore 
-# instead of a space to separate words.
+# The network name must be the same as the id that appears in the `blockchainCredentialSupportedNetworks` list 
+# exported from the `@bandada/utils` package but with capital letters. E.g. polygon_mumbai would be POLYGON_MUMBAI.
 
 SEPOLIA_RPC_URL=
 POLYGON_MUMBAI_RPC_URL=
 OPTIMISM_SEPOLIA_RPC_URL=
 ARBITRUM_SEPOLIA_RPC_URL=
+AVALANCHE_C_CHAIN_FUJI_RPC_URL=

--- a/apps/api/src/app/credentials/credentials.service.test.ts
+++ b/apps/api/src/app/credentials/credentials.service.test.ts
@@ -19,7 +19,12 @@ jest.mock("@bandada/utils", () => ({
         }),
         getGroups: () => []
     }),
-    blockchainCredentialSupportedNetworks: ["Sepolia"]
+    blockchainCredentialSupportedNetworks: [
+        {
+            id: "sepolia",
+            name: "Sepolia"
+        }
+    ]
 }))
 
 jest.mock("@bandada/credentials", () => ({

--- a/apps/api/src/app/credentials/credentials.service.ts
+++ b/apps/api/src/app/credentials/credentials.service.ts
@@ -108,18 +108,15 @@ export class CredentialsService {
         if (address) {
             const { network } = JSON.parse(group.credentials).criteria
 
-            if (
-                !blockchainCredentialSupportedNetworks.some(
-                    (n) => n.toLowerCase() === network.toLowerCase()
-                )
-            ) {
-                throw new BadRequestException(`The network is not supported`)
-            }
+            const supportedNetwork = blockchainCredentialSupportedNetworks.find(
+                (n) => n.name.toLowerCase() === network.toLowerCase()
+            )
 
-            const networkEnvVariableName = (network as string)
-                .split(" ")
-                .join("_")
-                .toUpperCase()
+            if (supportedNetwork === undefined)
+                throw new BadRequestException(`The network is not supported`)
+
+            const networkEnvVariableName = supportedNetwork.id.toUpperCase()
+
             const web3providerRpcURL =
                 process.env[`${networkEnvVariableName}_RPC_URL`]
 

--- a/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
+++ b/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
@@ -245,9 +245,11 @@ export default function AccessModeStep({
                                                 }
                                             >
                                                 {blockchainCredentialSupportedNetworks.map(
-                                                    (network: string) => (
-                                                        <option value={network}>
-                                                            {network}
+                                                    (network: any) => (
+                                                        <option
+                                                            value={network.name}
+                                                        >
+                                                            {network.name}
                                                         </option>
                                                     )
                                                 )}

--- a/libs/utils/src/getSupportedNetworks.ts
+++ b/libs/utils/src/getSupportedNetworks.ts
@@ -1,6 +1,24 @@
-export const blockchainCredentialSupportedNetworks: string[] = [
-    "Sepolia",
-    "Polygon Mumbai",
-    "Optimism Sepolia",
-    "Arbitrum Sepolia"
+import type { BlockchainNetwork } from "./types"
+
+export const blockchainCredentialSupportedNetworks: BlockchainNetwork[] = [
+    {
+        id: "sepolia",
+        name: "Sepolia"
+    },
+    {
+        id: "polygon_mumbai",
+        name: "Polygon Mumbai"
+    },
+    {
+        id: "optimism_sepolia",
+        name: "Optimism Sepolia"
+    },
+    {
+        id: "arbitrum_sepolia",
+        name: "Arbitrum Sepolia"
+    },
+    {
+        id: "avalanche_c_chain_fuji",
+        name: "Avalanche C-Chain Fuji"
+    }
 ]

--- a/libs/utils/src/types/index.ts
+++ b/libs/utils/src/types/index.ts
@@ -7,3 +7,8 @@ export type OnchainBandadaGroup = {
     id: BigInt
     fingerprint: BigInt
 }
+
+export type BlockchainNetwork = {
+    id: string
+    name: string
+}


### PR DESCRIPTION
## Description

This PR:

- Adds Avalanche C-Chain Fuji as a supported network in the blockchain credential.

- Updates the `blockchainCredentialSupportedNetworks` variable type to make it easier to identify a network and display its name.

## Related Issue

Closes #451

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No


