### PR TITLE
Update Repo Link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We're really glad you're reading this, because we need volunteer developers to h
 
 ## Issues
 
-The best way to contribute to our projects is by opening a [new issue](https://github.com/privacy-scaling-explorations/bandada/issues/new/choose) or tackling one of the issues listed [here](https://github.com/privacy-scaling-explorations/bandada/contribute).
+The best way to contribute to our projects is by opening a [new issue](https://github.com/bandada-infra/bandada/issues/new/choose) or tackling one of the issues listed [here](https://github.com/bandada-infra/bandada/contribute).
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations" target="_blank">
+    <a href="https://github.com/bandada-infra" target="_blank">
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/LICENSE">
+    <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
         <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/bandada/actions?query=workflow%3Atest">
+    <a href="https://github.com/bandada-infra/bandada/actions?query=workflow%3Atest">
         <img alt="GitHub Workflow test" src="https://img.shields.io/github/actions/workflow/status/privacy-scaling-explorations/bandada/test.yml?branch=main&label=test&style=flat-square&logo=github">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/bandada/actions?query=workflow%3Astyle">
+    <a href="https://github.com/bandada-infra/bandada/actions?query=workflow%3Astyle">
         <img alt="GitHub Workflow style" src="https://img.shields.io/github/actions/workflow/status/privacy-scaling-explorations/bandada/style.yml?branch=main&label=style&style=flat-square&logo=github">
     </a>
     <a href="https://coveralls.io/github/privacy-scaling-explorations/bandada">
@@ -39,7 +39,7 @@
             🤝 Code of conduct
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/contribute">
+        <a href="https://github.com/bandada-infra/bandada/contribute">
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
@@ -195,7 +195,7 @@ The applications will be deployed at the following URLs without any changes to t
 Clone this repository:
 
 ```bash
-git clone https://github.com/privacy-scaling-explorations/bandada.git
+git clone https://github.com/bandada-infra/bandada.git
 ```
 
 and install the dependencies:

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
     <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
-        <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
+        <img alt="Github license" src="https://img.shields.io/github/license/bandada-infra/bandada.svg?style=flat-square">
     </a>
     <a href="https://github.com/bandada-infra/bandada/actions?query=workflow%3Atest">
-        <img alt="GitHub Workflow test" src="https://img.shields.io/github/actions/workflow/status/privacy-scaling-explorations/bandada/test.yml?branch=main&label=test&style=flat-square&logo=github">
+        <img alt="GitHub Workflow test" src="https://img.shields.io/github/actions/workflow/status/bandada-infra/bandada/test.yml?branch=main&label=test&style=flat-square&logo=github">
     </a>
     <a href="https://github.com/bandada-infra/bandada/actions?query=workflow%3Astyle">
-        <img alt="GitHub Workflow style" src="https://img.shields.io/github/actions/workflow/status/privacy-scaling-explorations/bandada/style.yml?branch=main&label=style&style=flat-square&logo=github">
+        <img alt="GitHub Workflow style" src="https://img.shields.io/github/actions/workflow/status/bandada-infra/bandada/style.yml?branch=main&label=style&style=flat-square&logo=github">
     </a>
-    <a href="https://coveralls.io/github/privacy-scaling-explorations/bandada">
-        <img alt="Coveralls" src="https://img.shields.io/coveralls/github/privacy-scaling-explorations/bandada?label=coverage (ts)&style=flat-square&logo=coveralls">
+    <a href="https://coveralls.io/github/bandada-infra/bandada">
+        <img alt="Coveralls" src="https://img.shields.io/coveralls/github/bandada-infra/bandada?label=coverage (ts)&style=flat-square&logo=coveralls">
     </a>
     <a href="https://eslint.org/">
         <img alt="Linter eslint" src="https://img.shields.io/badge/linter-eslint-8080f2?style=flat-square&logo=eslint">
@@ -288,7 +288,7 @@ Bandada offers APIs for retrieving group data and managing group members. As an 
 
 To enable API access for a group, go to the group page in the dashboard and toggle the **Enable API Access** button. Once enabled, a new API key will be generated for you. You can disable API access at any time using the same toggle button.
 
-[Enable API access toggle for off-chain group](https://github.com/privacy-scaling-explorations/bandada/assets/20580910/e7106f24-39c8-422d-97a5-11756200ae03)
+[Enable API access toggle for off-chain group](https://github.com/bandada-infra/bandada/assets/20580910/e7106f24-39c8-422d-97a5-11756200ae03)
 
 ## 🔌 APIs endpoints
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -39,7 +39,7 @@ async function bootstrap() {
 
     const latestVersion = await (
         await fetch(
-            "https://api.github.com/repos/privacy-scaling-explorations/bandada/releases/latest"
+            "https://api.github.com/repos/bandada-infra/bandada/releases/latest"
         )
     ).json()
 
@@ -54,9 +54,9 @@ async function bootstrap() {
     const configUI = {
         swaggerOptions: { defaultModelsExpandDepth: -1 },
         customfavIcon:
-            "https://raw.githubusercontent.com/privacy-scaling-explorations/bandada/main/apps/dashboard/src/assets/favicon.ico",
+            "https://raw.githubusercontent.com/bandada-infra/bandada/main/apps/dashboard/src/assets/favicon.ico",
         customSiteTitle: "Bandada API Docs",
-        customCss: `.topbar-wrapper img {content:url('https://raw.githubusercontent.com/privacy-scaling-explorations/bandada/d5268274cbb93f73a1960e131bff0d2bf1eacea9/apps/dashboard/src/assets/icon1.svg'); width:60px; height:auto;}
+        customCss: `.topbar-wrapper img {content:url('https://raw.githubusercontent.com/bandada-infra/bandada/d5268274cbb93f73a1960e131bff0d2bf1eacea9/apps/dashboard/src/assets/icon1.svg'); width:60px; height:auto;}
         .swagger-ui .topbar { background-color: transparent; } small.version-stamp { display: none !important; }`,
         customJsStr: `
     // Add a custom title to the right side of the Swagger UI page

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -76,7 +76,7 @@ async function bootstrap() {
 
         // Create a hyperlink element
         const link = document.createElement('a');
-        link.href = 'https://github.com/privacy-scaling-explorations/bandada';
+        link.href = 'https://github.com/bandada-infra/bandada';
         link.rel = 'noreferrer noopener nofollow';
         link.target = '_blank'
         link.style.color = 'grey';

--- a/apps/client/src/pages/home.tsx
+++ b/apps/client/src/pages/home.tsx
@@ -158,7 +158,7 @@ export default function HomePage(): JSX.Element {
 
                     <HStack spacing="5">
                         <Link
-                            href="https://github.com/privacy-scaling-explorations/bandada"
+                            href="https://github.com/bandada-infra/bandada"
                             isExternal
                         >
                             <HStack spacing="1">

--- a/apps/contracts/contracts/README.md
+++ b/apps/contracts/contracts/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/bandada">
+    <a href="https://github.com/bandada-infra/bandada">
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/LICENSE">
+    <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
         <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/contracts">
@@ -22,15 +22,15 @@
 
 <div align="center">
     <h4>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CONTRIBUTING.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CONTRIBUTING.md">
             👥 Contributing
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CODE_OF_CONDUCT.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CODE_OF_CONDUCT.md">
             🤝 Code of conduct
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/contribute">
+        <a href="https://github.com/bandada-infra/bandada/contribute">
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>

--- a/apps/contracts/contracts/README.md
+++ b/apps/contracts/contracts/README.md
@@ -10,7 +10,7 @@
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
     <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
-        <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
+        <img alt="Github license" src="https://img.shields.io/github/license/bandada-infra/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/contracts">
         <img alt="NPM version" src="https://img.shields.io/npm/v/@bandada/contracts?style=flat-square" />

--- a/apps/contracts/contracts/package.json
+++ b/apps/contracts/contracts/package.json
@@ -20,10 +20,10 @@
         "zero-knowledge-proofs",
         "proof-of-membership"
     ],
-    "repository": "https://github.com/privacy-scaling-explorations/bandada",
-    "homepage": "https://github.com/privacy-scaling-explorations/bandada/tree/main/packages/contracts",
+    "repository": "https://github.com/bandada-infra/bandada",
+    "homepage": "https://github.com/bandada-infra/bandada/tree/main/packages/contracts",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/bandada.git/issues"
+        "url": "https://github.com/bandada-infra/bandada.git/issues"
     },
     "publishConfig": {
         "access": "public"

--- a/apps/dashboard/src/pages/home.tsx
+++ b/apps/dashboard/src/pages/home.tsx
@@ -56,7 +56,7 @@ export default function HomePage(): JSX.Element {
 
                                 <HStack spacing="5">
                                     <Link
-                                        href="https://github.com/privacy-scaling-explorations/bandada"
+                                        href="https://github.com/bandada-infra/bandada"
                                         isExternal
                                     >
                                         <HStack spacing="1">

--- a/apps/docs/docs/api/api-sdk.md
+++ b/apps/docs/docs/api/api-sdk.md
@@ -7,7 +7,7 @@ import TabItem from "@theme/TabItem"
 
 # API SDK
 
-[The API SDK JavaScript package](https://github.com/privacy-scaling-explorations/bandada/tree/main/libs/api-sdk) provides a list of functions to make it easier to work with the Bandada API. 
+[The API SDK JavaScript package](https://github.com/bandada-infra/bandada/tree/main/libs/api-sdk) provides a list of functions to make it easier to work with the Bandada API. 
 
 Example of project using the API SDK library: [bandada-api-sdk-demo](https://github.com/bandada-infra/bandada-sdk-demo).
 
@@ -60,7 +60,7 @@ import { ApiSdk } from "@bandada/api-sdk"
 const apiSdk = new ApiSdk()
 ```
 
--   Creates a new instance using a [Supported URL](https://github.com/privacy-scaling-explorations/bandada/blob/main/libs/api-sdk/src/types/index.ts#L43). 
+-   Creates a new instance using a [Supported URL](https://github.com/bandada-infra/bandada/blob/main/libs/api-sdk/src/types/index.ts#L43). 
 
 This is useful when working with the development environment.
 

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -91,7 +91,7 @@ const config: Config = {
                         },
                         {
                             label: "GitHub",
-                            href: "https://github.com/privacy-scaling-explorations/bandada"
+                            href: "https://github.com/bandada-infra/bandada"
                         },
                         {
                             label: "X (Twitter)",

--- a/apps/docs/static/data/articles.json
+++ b/apps/docs/static/data/articles.json
@@ -4,6 +4,6 @@
         "minRead": 3,
         "date": "2023-08-23",
         "authors": ["Bandada team"],
-        "url": "https://mirror.xyz/privacy-scaling-explorations.eth/p3Mtft28FG1ctgeUARVEKLTK_KexnWC6T4CUHaQark4"
+        "url": "https://mirror.xyz/bandada-infra.eth/p3Mtft28FG1ctgeUARVEKLTK_KexnWC6T4CUHaQark4"
     }
 ]

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/bandada">
+    <a href="https://github.com/bandada-infra/bandada">
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/LICENSE">
+    <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
         <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/api-sdk">
@@ -28,15 +28,15 @@
 
 <div align="center">
     <h4>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CONTRIBUTING.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CONTRIBUTING.md">
             👥 Contributing
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CODE_OF_CONDUCT.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CODE_OF_CONDUCT.md">
             🤝 Code of conduct
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/contribute">
+        <a href="https://github.com/bandada-infra/bandada/contribute">
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -10,7 +10,7 @@
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
     <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
-        <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
+        <img alt="Github license" src="https://img.shields.io/github/license/bandada-infra/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/api-sdk">
         <img alt="NPM version" src="https://img.shields.io/npm/v/@bandada/api-sdk?style=flat-square" />

--- a/libs/api-sdk/package.json
+++ b/libs/api-sdk/package.json
@@ -15,10 +15,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "https://github.com/privacy-scaling-explorations/bandada",
-    "homepage": "https://github.com/privacy-scaling-explorations/bandada/tree/main/libs/api-sdk",
+    "repository": "https://github.com/bandada-infra/bandada",
+    "homepage": "https://github.com/bandada-infra/bandada/tree/main/libs/api-sdk",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/bandada.git/issues"
+        "url": "https://github.com/bandada-infra/bandada.git/issues"
     },
     "scripts": {
         "build:watch": "rollup -c rollup.config.ts -w --configPlugin typescript",

--- a/libs/credentials/README.md
+++ b/libs/credentials/README.md
@@ -10,7 +10,7 @@
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
     <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
-        <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
+        <img alt="Github license" src="https://img.shields.io/github/license/bandada-infra/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/credentials">
         <img alt="NPM version" src="https://img.shields.io/npm/v/@bandada/credentials?style=flat-square" />

--- a/libs/credentials/README.md
+++ b/libs/credentials/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/bandada">
+    <a href="https://github.com/bandada-infra/bandada">
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/LICENSE">
+    <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
         <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/credentials">
@@ -28,15 +28,15 @@
 
 <div align="center">
     <h4>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CONTRIBUTING.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CONTRIBUTING.md">
             👥 Contributing
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CODE_OF_CONDUCT.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CODE_OF_CONDUCT.md">
             🤝 Code of conduct
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/contribute">
+        <a href="https://github.com/bandada-infra/bandada/contribute">
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>

--- a/libs/credentials/package.json
+++ b/libs/credentials/package.json
@@ -15,10 +15,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "https://github.com/privacy-scaling-explorations/bandada",
-    "homepage": "https://github.com/privacy-scaling-explorations/bandada/tree/main/libs/credentials",
+    "repository": "https://github.com/bandada-infra/bandada",
+    "homepage": "https://github.com/bandada-infra/bandada/tree/main/libs/credentials",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/bandada.git/issues"
+        "url": "https://github.com/bandada-infra/bandada.git/issues"
     },
     "scripts": {
         "build:watch": "rollup -c rollup.config.ts -w --configPlugin typescript",

--- a/libs/hardhat/README.md
+++ b/libs/hardhat/README.md
@@ -10,7 +10,7 @@
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
     <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
-        <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
+        <img alt="Github license" src="https://img.shields.io/github/license/bandada-infra/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/hardhat">
         <img alt="NPM version" src="https://img.shields.io/npm/v/@bandada/hardhat?style=flat-square" />

--- a/libs/hardhat/README.md
+++ b/libs/hardhat/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/bandada">
+    <a href="https://github.com/bandada-infra/bandada">
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/LICENSE">
+    <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
         <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/hardhat">
@@ -28,15 +28,15 @@
 
 <div align="center">
     <h4>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CONTRIBUTING.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CONTRIBUTING.md">
             👥 Contributing
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CODE_OF_CONDUCT.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CODE_OF_CONDUCT.md">
             🤝 Code of conduct
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/contribute">
+        <a href="https://github.com/bandada-infra/bandada/contribute">
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>

--- a/libs/hardhat/package.json
+++ b/libs/hardhat/package.json
@@ -15,10 +15,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "https://github.com/privacy-scaling-explorations/bandada",
-    "homepage": "https://github.com/privacy-scaling-explorations/bandada/tree/main/libs/hardhat",
+    "repository": "https://github.com/bandada-infra/bandada",
+    "homepage": "https://github.com/bandada-infra/bandada/tree/main/libs/hardhat",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/bandada.git/issues"
+        "url": "https://github.com/bandada-infra/bandada.git/issues"
     },
     "scripts": {
         "build:watch": "rollup -c rollup.config.ts -w --configPlugin typescript",

--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -10,7 +10,7 @@
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
     <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
-        <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
+        <img alt="Github license" src="https://img.shields.io/github/license/bandada-infra/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/utils">
         <img alt="NPM version" src="https://img.shields.io/npm/v/@bandada/utils?style=flat-square" />

--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/bandada">
+    <a href="https://github.com/bandada-infra/bandada">
         <img src="https://img.shields.io/badge/project-Bandada-blue.svg?style=flat-square">
     </a>
-    <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/LICENSE">
+    <a href="https://github.com/bandada-infra/bandada/blob/main/LICENSE">
         <img alt="Github license" src="https://img.shields.io/github/license/privacy-scaling-explorations/bandada.svg?style=flat-square">
     </a>
     <a href="https://www.npmjs.com/package/@bandada/utils">
@@ -28,15 +28,15 @@
 
 <div align="center">
     <h4>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CONTRIBUTING.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CONTRIBUTING.md">
             👥 Contributing
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/blob/main/CODE_OF_CONDUCT.md">
+        <a href="https://github.com/bandada-infra/bandada/blob/main/CODE_OF_CONDUCT.md">
             🤝 Code of conduct
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>
-        <a href="https://github.com/privacy-scaling-explorations/bandada/contribute">
+        <a href="https://github.com/bandada-infra/bandada/contribute">
             🔎 Issues
         </a>
         <span>&nbsp;&nbsp;|&nbsp;&nbsp;</span>

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -15,10 +15,10 @@
         "LICENSE",
         "README.md"
     ],
-    "repository": "https://github.com/privacy-scaling-explorations/bandada",
-    "homepage": "https://github.com/privacy-scaling-explorations/bandada/tree/main/libs/utils",
+    "repository": "https://github.com/bandada-infra/bandada",
+    "homepage": "https://github.com/bandada-infra/bandada/tree/main/libs/utils",
     "bugs": {
-        "url": "https://github.com/privacy-scaling-explorations/bandada.git/issues"
+        "url": "https://github.com/bandada-infra/bandada.git/issues"
     },
     "scripts": {
         "build:watch": "rollup -c rollup.config.ts -w --configPlugin typescript",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
     "name": "bandada",
     "description": "A system for managing privacy-preserving groups.",
     "license": "MIT",
-    "repository": "git@github.com:privacy-scaling-explorations/bandada.git",
-    "homepage": "https://github.com/privacy-scaling-explorations/bandada",
-    "bugs": "https://github.com/privacy-scaling-explorations/bandada/issues",
+    "repository": "git@github.com:bandada-infra/bandada.git",
+    "homepage": "https://github.com/bandada-infra/bandada",
+    "bugs": "https://github.com/bandada-infra/bandada/issues",
     "private": true,
     "scripts": {
         "start": "yarn workspaces foreach --exclude bandada-docs -A -pi run start",


### PR DESCRIPTION
## Description

This PR updates the repo link across the codebase by replacing the old link `github.com/privacy-scaling-explorations/bandada` with the new link `github.com/bandada-infra/bandada`. The update is applied to all files and locations where the old repo link was referenced.

## Related Issue

Closes #442 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No