### PR TITLE
Fix API Key component not working properly

### DIFF
--- a/apps/dashboard/src/components/api-key.tsx
+++ b/apps/dashboard/src/components/api-key.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import {
     Box,
     Flex,
@@ -26,7 +26,7 @@ export default function ApiKeyComponent({
     const { onCopy } = useClipboard(apiKey)
     const toast = useToast()
 
-    useEffect(() => {
+    const getAdminInfo = useCallback(async () => {
         getAdmin(adminId).then((admin) => {
             if (admin) {
                 setAdmin(admin)
@@ -35,6 +35,10 @@ export default function ApiKeyComponent({
             }
         })
     }, [adminId])
+
+    useEffect(() => {
+        getAdminInfo()
+    }, [getAdminInfo])
 
     useEffect(() => {
         if (isCopied) {
@@ -91,7 +95,7 @@ export default function ApiKeyComponent({
                     "Successfully refreshed",
                     "success"
                 )
-                setApiKey(newApiKey)
+                getAdminInfo()
             }
         }
     }
@@ -132,9 +136,8 @@ export default function ApiKeyComponent({
                         ? "API key has been enabled."
                         : "API key has been disabled."
             }
-
+            getAdminInfo()
             showToast(toastTitle, toastDescription, "success")
-            setIsEnabled((prevState) => !prevState)
         }
     }
 


### PR DESCRIPTION
## Description

The issue is that the API Key component information was not being updated properly. 

Right now, when refreshing the API Key or the API Key is enabled or disabled, there are two requests to the backend: one to update admin info and the other to get the admin info. Since all the info to update is in the frontend, it shouldn't be necessary to send the second request. Since those functions won't be used frequently, this code can be refactored in another Pull Request.

## Related Issue

#463 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

