### PR TITLE
Refactor API SDK

### DIFF
--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -161,6 +161,8 @@ export class GroupsService {
                 .toString()
                 .slice(0, 32)
 
+        if (credentials === undefined) credentials = null
+
         const group = this.groupRepository.create({
             id: _groupId,
             name,

--- a/apps/client/src/pages/home.tsx
+++ b/apps/client/src/pages/home.tsx
@@ -114,7 +114,7 @@ export default function HomePage(): JSX.Element {
 
                 const group = await getGroup(groupId)
 
-                if (group === null) {
+                if (group === null || group.credentials === null) {
                     setLoading(false)
                     return
                 }

--- a/apps/client/src/utils/api.ts
+++ b/apps/client/src/utils/api.ts
@@ -1,10 +1,8 @@
-import { ApiSdk, GroupResponse, InviteResponse } from "@bandada/api-sdk"
+import { ApiSdk, Group, Invite } from "@bandada/api-sdk"
 
 const api = new ApiSdk(import.meta.env.VITE_API_URL)
 
-export async function getInvite(
-    inviteCode: string
-): Promise<InviteResponse | null> {
+export async function getInvite(inviteCode: string): Promise<Invite | null> {
     try {
         return await api.getInvite(inviteCode)
     } catch (error: any) {
@@ -20,7 +18,7 @@ export async function getInvite(
     }
 }
 
-export async function getGroup(groupId: string): Promise<GroupResponse | null> {
+export async function getGroup(groupId: string): Promise<Group | null> {
     try {
         return await api.getGroup(groupId)
     } catch (error: any) {

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -71,21 +71,39 @@ yarn add @bandada/api-sdk
 
 Creates a new instance of ApiSdk using the API URL and the [config](https://axios-http.com/docs/req_config).
 
--   Creates a new instance using the Bandada API URL and the default config.
+-   Create a new instance using the Bandada API URL and the default config.
+
+This is what you need if you are using the production Bandada API.
 
 ```ts
+import { ApiSdk } from "@bandada/api-sdk"
+
 const apiSdk = new ApiSdk()
 ```
 
--   Creates a new instance using a custom API URL.
+-   Create a new instance using a [Supported URL](https://github.com/bandada-infra/bandada/blob/main/libs/api-sdk/src/types/index.ts#L43).
+
+This is useful when working with the development environment.
 
 ```ts
+import { ApiSdk, SupportedUrl } from "@bandada/api-sdk"
+
+const apiSdk = new ApiSdk(SupportedUrl.DEV)
+```
+
+-   Create a new instance using a custom API URL.
+
+```ts
+import { ApiSdk } from "@bandada/api-sdk"
+
 const apiSdk = new ApiSdk("https://example.com/api")
 ```
 
--   Creates a new instance using a custom API URL and config.
+-   Create a new instance using a custom API URL and config.
 
 ```ts
+import { ApiSdk } from "@bandada/api-sdk"
+
 const url = "https://example.com/api"
 const config = {
     headers: {
@@ -95,7 +113,7 @@ const config = {
 const apiSdk = new ApiSdk(url, config)
 ```
 
-\# **getGroups**(): _Promise\<GroupResponse[]>_
+\# **getGroups**(): _Promise\<Group[]>_
 
 Returns the list of groups.
 
@@ -103,7 +121,7 @@ Returns the list of groups.
 const groups = await apiSdk.getGroups()
 ```
 
-\# **getGroup**(): _Promise\<GroupResponse>_
+\# **getGroup**(): _Promise\<Group>_
 
 Returns a specific group.
 

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -113,6 +113,113 @@ const config = {
 const apiSdk = new ApiSdk(url, config)
 ```
 
+\# **createGroup**(): _Promise\<Group>_
+
+Creates a Bandada group.
+
+```ts
+const groupCreateDetails = {
+    name: "Group 1",
+    description: "This is Group 1.",
+    treeDepth: 16,
+    fingerprintDuration: 3600
+}
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+const group = await apiSdk.createGroup(groupCreateDetails, apiKey)
+```
+
+\# **createGroups**(): _Promise\<Group[]>_
+
+Creates one or many Bandada groups.
+
+```ts
+const groupsCreateDetails = [
+    {
+        name: "Group 1",
+        description: "This is Group 1.",
+        treeDepth: 16,
+        fingerprintDuration: 3600
+    },
+    {
+        name: "Group 2",
+        description: "This is Group 2.",
+        treeDepth: 16,
+        fingerprintDuration: 3600
+    }
+]
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+const groups = await apiSdk.createGroups(groupsCreateDetails, apiKey)
+```
+
+\# **removeGroup**(): _Promise\<void>_
+
+Removes a specific Bandada group.
+
+```ts
+const groupId = "10402173435763029700781503965100"
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+await apiSdk.removeGroup(groupId, apiKey)
+```
+
+\# **removeGroups**(): _Promise\<void>_
+
+Removes one or many Bandada groups.
+
+```ts
+const groupIds = [
+    "10402173435763029700781503965100",
+    "20402173435763029700781503965200"
+]
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+await apiSdk.removeGroups(groupIds, apiKey)
+```
+
+\# **updateGroup**(): _Promise\<Group>_
+
+Updates a specific Bandada group.
+
+```ts
+const groupId = "10402173435763029700781503965100"
+const groupUpdateDetails = {
+    description: "This is a new group.",
+    treeDepth: 20,
+    fingerprintDuration: 4000
+}
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+await apiSdk.updateGroup(groupId, groupUpdateDetails, apiKey)
+```
+
+\# **updateGroups**(): _Promise\<Group[]>_
+
+Updates one or many Bandada groups.
+
+```ts
+const groupIds = [
+    "10402173435763029700781503965100",
+    "20402173435763029700781503965200"
+]
+const updatedGroups: Array<GroupUpdateDetails> = [
+    {
+        description: "This is a new group1.",
+        treeDepth: 32,
+        fingerprintDuration: 7200
+    },
+    {
+        description: "This is a new group2.",
+        treeDepth: 32,
+        fingerprintDuration: 7200
+    }
+]
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+await apiSdk.updateGroups(groupId, groupUpdateDetails, apiKey)
+```
+
 \# **getGroups**(): _Promise\<Group[]>_
 
 Returns the list of groups.
@@ -211,4 +318,15 @@ const memberIds = ["1", "2", "3"]
 const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 
 await apiSdk.removeMembersByApiKey(groupId, memberIds, apiKey)
+```
+
+\# **getInvite**(): _Promise\<Invite>_
+
+Returns a specific invite.
+
+```ts
+const inviteCode = "C5VAG4HD"
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+const invite = await apiSdk.getInvite(inviteCode)
 ```

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -87,30 +87,30 @@ export default class ApiSdk {
 
     /**
      * Creates a group using the API key.
-     * @param groupData Data to create the group.
+     * @param groupCreationDetails Data to create the group.
      * @param apiKey The API key of the admin of the group.
      * @returns The created group.
      */
     async createGroup(
-        groupData: GroupCreationDetails,
+        groupCreationDetails: GroupCreationDetails,
         apiKey: string
     ): Promise<Group> {
-        const groups = await createGroups(this._config, [groupData], apiKey)
+        const groups = await createGroups(this._config, [groupCreationDetails], apiKey)
 
         return groups[0]
     }
 
     /**
      * Creates one or more groups using the API key.
-     * @param groupsData Data to create the groups.
+     * @param groupsCreationDetails Data to create the groups.
      * @param apiKey The API key of the admin of the groups.
      * @returns The created groups.
      */
     async createGroups(
-        groupsData: Array<GroupCreationDetails>,
+        groupsCreationDetails: Array<GroupCreationDetails>,
         apiKey: string
     ): Promise<Array<Group>> {
-        const groups = await createGroups(this._config, groupsData, apiKey)
+        const groups = await createGroups(this._config, groupsCreationDetails, apiKey)
 
         return groups
     }
@@ -138,19 +138,19 @@ export default class ApiSdk {
     /**
      * Update a specific group using the API key.
      * @param groupId The group id.
-     * @param groupData Data to update the group.
+     * @param groupUpdateDetails Data to update the group.
      * @param apiKey The API key of the admin of the group.
      * @returns The updated group.
      */
     async updateGroup(
         groupId: string,
-        groupData: GroupUpdateDetails,
+        groupUpdateDetails: GroupUpdateDetails,
         apiKey: string
     ): Promise<Group> {
         const group = await updateGroup(
             this._config,
             groupId,
-            groupData,
+            groupUpdateDetails,
             apiKey
         )
 
@@ -160,19 +160,19 @@ export default class ApiSdk {
     /**
      * Updats one or more groups using the API key.
      * @param groupIds The group ids.
-     * @param groupsData Data to update the groups.
+     * @param groupsUpdateDetails Data to update the groups.
      * @param apiKey The API key of the admin of the groups.
      * @returns The updated groups.
      */
     async updateGroups(
         groupIds: Array<string>,
-        groupsData: Array<GroupUpdateDetails>,
+        groupsUpdateDetails: Array<GroupUpdateDetails>,
         apiKey: string
     ): Promise<Array<Group>> {
         const groups = await updateGroups(
             this._config,
             groupIds,
-            groupsData,
+            groupsUpdateDetails,
             apiKey
         )
 

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -1,7 +1,7 @@
 import {
     SupportedUrl,
     Group,
-    InviteResponse,
+    Invite,
     GroupCreationDetails,
     GroupUpdateDetails
 } from "./types"
@@ -95,7 +95,11 @@ export default class ApiSdk {
         groupCreationDetails: GroupCreationDetails,
         apiKey: string
     ): Promise<Group> {
-        const groups = await createGroups(this._config, [groupCreationDetails], apiKey)
+        const groups = await createGroups(
+            this._config,
+            [groupCreationDetails],
+            apiKey
+        )
 
         return groups[0]
     }
@@ -110,7 +114,11 @@ export default class ApiSdk {
         groupsCreationDetails: Array<GroupCreationDetails>,
         apiKey: string
     ): Promise<Array<Group>> {
-        const groups = await createGroups(this._config, groupsCreationDetails, apiKey)
+        const groups = await createGroups(
+            this._config,
+            groupsCreationDetails,
+            apiKey
+        )
 
         return groups
     }
@@ -301,7 +309,7 @@ export default class ApiSdk {
      * @param inviteCode Invite code.
      * @returns Specific invite.
      */
-    async getInvite(inviteCode: string): Promise<InviteResponse> {
+    async getInvite(inviteCode: string): Promise<Invite> {
         const invite = getInvite(this._config, inviteCode)
 
         return invite

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -1,9 +1,9 @@
 import {
     SupportedUrl,
-    GroupResponse,
+    Group,
     InviteResponse,
-    GroupRequest,
-    GroupUpdateRequest
+    GroupCreationDetails,
+    GroupUpdateDetails
 } from "./types"
 import checkParameter from "./checkParameter"
 import {
@@ -79,7 +79,7 @@ export default class ApiSdk {
      * Returns the list of groups.
      * @returns List of groups.
      */
-    async getGroups(): Promise<GroupResponse[]> {
+    async getGroups(): Promise<Group[]> {
         const groups = await getGroups(this._config)
 
         return groups
@@ -92,9 +92,9 @@ export default class ApiSdk {
      * @returns The created group.
      */
     async createGroup(
-        groupData: GroupRequest,
+        groupData: GroupCreationDetails,
         apiKey: string
-    ): Promise<GroupResponse> {
+    ): Promise<Group> {
         const groups = await createGroups(this._config, [groupData], apiKey)
 
         return groups[0]
@@ -107,9 +107,9 @@ export default class ApiSdk {
      * @returns The created groups.
      */
     async createGroups(
-        groupsData: Array<GroupRequest>,
+        groupsData: Array<GroupCreationDetails>,
         apiKey: string
-    ): Promise<Array<GroupResponse>> {
+    ): Promise<Array<Group>> {
         const groups = await createGroups(this._config, groupsData, apiKey)
 
         return groups
@@ -144,9 +144,9 @@ export default class ApiSdk {
      */
     async updateGroup(
         groupId: string,
-        groupData: GroupUpdateRequest,
+        groupData: GroupUpdateDetails,
         apiKey: string
-    ): Promise<GroupResponse> {
+    ): Promise<Group> {
         const group = await updateGroup(
             this._config,
             groupId,
@@ -166,9 +166,9 @@ export default class ApiSdk {
      */
     async updateGroups(
         groupIds: Array<string>,
-        groupsData: Array<GroupUpdateRequest>,
+        groupsData: Array<GroupUpdateDetails>,
         apiKey: string
-    ): Promise<Array<GroupResponse>> {
+    ): Promise<Array<Group>> {
         const groups = await updateGroups(
             this._config,
             groupIds,
@@ -184,7 +184,7 @@ export default class ApiSdk {
      * @param groupId Group id.
      * @returns Specific group.
      */
-    async getGroup(groupId: string): Promise<GroupResponse> {
+    async getGroup(groupId: string): Promise<Group> {
         const group = await getGroup(this._config, groupId)
 
         return group

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -1,5 +1,5 @@
 import { request } from "@bandada/utils"
-import { GroupRequest, GroupResponse, GroupUpdateRequest } from "./types"
+import type { GroupCreationDetails, Group, GroupUpdateDetails } from "./types"
 
 const url = "/groups"
 
@@ -7,7 +7,7 @@ const url = "/groups"
  * Returns the list of groups.
  * @returns List of groups.
  */
-export async function getGroups(config: object): Promise<GroupResponse[]> {
+export async function getGroups(config: object): Promise<Group[]> {
     const groups = await request(url, config)
 
     groups.map((group: any) => ({
@@ -26,9 +26,9 @@ export async function getGroups(config: object): Promise<GroupResponse[]> {
  */
 export async function createGroups(
     config: object,
-    groupsData: Array<GroupRequest>,
+    groupsData: Array<GroupCreationDetails>,
     apiKey: string
-): Promise<Array<GroupResponse>> {
+): Promise<Array<Group>> {
     const newConfig: any = {
         method: "post",
         data: groupsData,
@@ -101,9 +101,9 @@ export async function removeGroups(
 export async function updateGroup(
     config: object,
     groupId: string,
-    groupData: GroupUpdateRequest,
+    groupData: GroupUpdateDetails,
     apiKey: string
-): Promise<GroupResponse> {
+): Promise<Group> {
     const requestUrl = `${url}/${groupId}`
 
     const newConfig: any = {
@@ -131,9 +131,9 @@ export async function updateGroup(
 export async function updateGroups(
     config: object,
     groupIds: Array<string>,
-    groupsData: Array<GroupUpdateRequest>,
+    groupsData: Array<GroupUpdateDetails>,
     apiKey: string
-): Promise<Array<GroupResponse>> {
+): Promise<Array<Group>> {
     const newConfig: any = {
         method: "put",
         data: {
@@ -158,7 +158,7 @@ export async function updateGroups(
 export async function getGroup(
     config: object,
     groupId: string
-): Promise<GroupResponse> {
+): Promise<Group> {
     const requestUrl = `${url}/${groupId}`
 
     const group = await request(requestUrl, config)

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -31,9 +31,7 @@ export async function createGroups(
 ): Promise<Array<GroupResponse>> {
     const newConfig: any = {
         method: "post",
-        data: {
-            groupsData
-        },
+        data: groupsData,
         ...config
     }
 

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -20,18 +20,18 @@ export async function getGroups(config: object): Promise<Group[]> {
 
 /**
  * Creates one or more groups with the provided details.
- * @param groupsData Data to create the groups.
+ * @param groupsCreationDetails Data to create the groups.
  * @param apiKey API Key of the admin.
  * @returns Array of the created groups.
  */
 export async function createGroups(
     config: object,
-    groupsData: Array<GroupCreationDetails>,
+    groupsCreationDetails: Array<GroupCreationDetails>,
     apiKey: string
 ): Promise<Array<Group>> {
     const newConfig: any = {
         method: "post",
-        data: groupsData,
+        data: groupsCreationDetails,
         ...config
     }
 
@@ -94,14 +94,14 @@ export async function removeGroups(
 /**
  * Updates the group.
  * @param groupId The group id.
- * @param groupData Data to update the group.
+ * @param groupUpdateDetails Data to update the group.
  * @param apiKey API Key of the admin.
  * @return The updated group.
  */
 export async function updateGroup(
     config: object,
     groupId: string,
-    groupData: GroupUpdateDetails,
+    groupUpdateDetails: GroupUpdateDetails,
     apiKey: string
 ): Promise<Group> {
     const requestUrl = `${url}/${groupId}`
@@ -109,7 +109,7 @@ export async function updateGroup(
     const newConfig: any = {
         method: "put",
         data: {
-            groupData
+            groupUpdateDetails
         },
         ...config
     }
@@ -124,21 +124,21 @@ export async function updateGroup(
 /**
  * Updates the groups.
  * @param groupIds The group ids.
- * @param groupsData Data to update the groups.
+ * @param groupsUpdateDetails Data to update the groups.
  * @param apiKey API Key of the admin.
  * @return The updated groups.
  */
 export async function updateGroups(
     config: object,
     groupIds: Array<string>,
-    groupsData: Array<GroupUpdateDetails>,
+    groupsUpdateDetails: Array<GroupUpdateDetails>,
     apiKey: string
 ): Promise<Array<Group>> {
     const newConfig: any = {
         method: "put",
         data: {
             groupIds,
-            groupsData
+            groupsUpdateDetails
         },
         ...config
     }

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -83,7 +83,6 @@ describe("Bandada API SDK", () => {
         describe("#createGroup", () => {
             it("Should create a group", async () => {
                 const expectedGroup: GroupRequest = {
-                    id: "10402173435763029700781503965100",
                     name: "Group1",
                     description: "This is a new group",
                     treeDepth: 16,
@@ -113,7 +112,6 @@ describe("Bandada API SDK", () => {
                     apiKey
                 )
 
-                expect(group.id).toBe(expectedGroup.id)
                 expect(group.description).toBe(expectedGroup.description)
                 expect(group.name).toBe(expectedGroup.name)
                 expect(group.treeDepth).toBe(expectedGroup.treeDepth)
@@ -128,14 +126,12 @@ describe("Bandada API SDK", () => {
             it("Should create the groups", async () => {
                 const expectedGroups: Array<GroupRequest> = [
                     {
-                        id: "10402173435763029700781503965100",
                         name: "Group1",
                         description: "This is a new group",
                         treeDepth: 16,
                         fingerprintDuration: 3600
                     },
                     {
-                        id: "20402173435763029700781503965200",
                         name: "Group2",
                         description: "This is a new group",
                         treeDepth: 32,
@@ -178,7 +174,6 @@ describe("Bandada API SDK", () => {
                 )
 
                 groups.forEach((group: GroupResponse, i: number) => {
-                    expect(group.id).toBe(expectedGroups[i].id)
                     expect(group.description).toBe(
                         expectedGroups[i].description
                     )

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -4,7 +4,7 @@ import {
     GroupCreationDetails,
     Group,
     GroupUpdateDetails,
-    InviteResponse,
+    Invite,
     SupportedUrl
 } from "./types"
 
@@ -550,9 +550,7 @@ describe("Bandada API SDK", () => {
                 const inviteCode = "C5VAG4HD"
 
                 apiSdk = new ApiSdk(SupportedUrl.DEV)
-                const invite: InviteResponse = await apiSdk.getInvite(
-                    inviteCode
-                )
+                const invite: Invite = await apiSdk.getInvite(inviteCode)
                 expect(invite.code).toBe(inviteCode)
             })
         })

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -1,9 +1,9 @@
 import { request } from "@bandada/utils"
 import ApiSdk from "./apiSdk"
 import {
-    GroupRequest,
-    GroupResponse,
-    GroupUpdateRequest,
+    GroupCreationDetails,
+    Group,
+    GroupUpdateDetails,
     InviteResponse,
     SupportedUrl
 } from "./types"
@@ -82,7 +82,7 @@ describe("Bandada API SDK", () => {
     describe("Groups", () => {
         describe("#createGroup", () => {
             it("Should create a group", async () => {
-                const expectedGroup: GroupRequest = {
+                const expectedGroup: GroupCreationDetails = {
                     name: "Group1",
                     description: "This is a new group",
                     treeDepth: 16,
@@ -107,7 +107,7 @@ describe("Bandada API SDK", () => {
                 )
 
                 apiSdk = new ApiSdk(SupportedUrl.DEV)
-                const group: GroupResponse = await apiSdk.createGroup(
+                const group: Group = await apiSdk.createGroup(
                     expectedGroup,
                     apiKey
                 )
@@ -124,7 +124,7 @@ describe("Bandada API SDK", () => {
         })
         describe("#createGroups", () => {
             it("Should create the groups", async () => {
-                const expectedGroups: Array<GroupRequest> = [
+                const expectedGroups: Array<GroupCreationDetails> = [
                     {
                         name: "Group1",
                         description: "This is a new group",
@@ -168,12 +168,12 @@ describe("Bandada API SDK", () => {
                 )
 
                 apiSdk = new ApiSdk(SupportedUrl.DEV)
-                const groups: Array<GroupResponse> = await apiSdk.createGroups(
+                const groups: Array<Group> = await apiSdk.createGroups(
                     [expectedGroups[0], expectedGroups[1]],
                     apiKey
                 )
 
-                groups.forEach((group: GroupResponse, i: number) => {
+                groups.forEach((group: Group, i: number) => {
                     expect(group.description).toBe(
                         expectedGroups[i].description
                     )
@@ -217,7 +217,7 @@ describe("Bandada API SDK", () => {
         describe("#updateGroup", () => {
             it("Should update a group", async () => {
                 const groupId = "10402173435763029700781503965100"
-                const updatedGroup: GroupUpdateRequest = {
+                const updatedGroup: GroupUpdateDetails = {
                     description: "This is a new group",
                     treeDepth: 16,
                     fingerprintDuration: 3600
@@ -239,7 +239,7 @@ describe("Bandada API SDK", () => {
                 )
 
                 apiSdk = new ApiSdk(SupportedUrl.DEV)
-                const group: GroupResponse = await apiSdk.updateGroup(
+                const group: Group = await apiSdk.updateGroup(
                     groupId,
                     updatedGroup,
                     apiKey
@@ -258,7 +258,7 @@ describe("Bandada API SDK", () => {
                     "10402173435763029700781503965100",
                     "20402173435763029700781503965200"
                 ]
-                const updatedGroups: Array<GroupUpdateRequest> = [
+                const updatedGroups: Array<GroupUpdateDetails> = [
                     {
                         description: "This is a new group1",
                         treeDepth: 32,
@@ -300,13 +300,13 @@ describe("Bandada API SDK", () => {
                 )
 
                 apiSdk = new ApiSdk(SupportedUrl.DEV)
-                const groups: Array<GroupResponse> = await apiSdk.updateGroups(
+                const groups: Array<Group> = await apiSdk.updateGroups(
                     groupIds,
                     updatedGroups,
                     apiKey
                 )
 
-                groups.forEach((group: GroupResponse, i: number) => {
+                groups.forEach((group: Group, i: number) => {
                     expect(group.description).toBe(updatedGroups[i].description)
                     expect(group.treeDepth).toBe(updatedGroups[i].treeDepth)
                     expect(group.fingerprintDuration).toBe(
@@ -333,7 +333,7 @@ describe("Bandada API SDK", () => {
                     ])
                 )
                 apiSdk = new ApiSdk(SupportedUrl.DEV)
-                const groups: GroupResponse[] = await apiSdk.getGroups()
+                const groups: Group[] = await apiSdk.getGroups()
                 expect(groups).toHaveLength(1)
             })
         })
@@ -355,7 +355,7 @@ describe("Bandada API SDK", () => {
                 const groupId = "10402173435763029700781503965100"
 
                 apiSdk = new ApiSdk(SupportedUrl.DEV)
-                const group: GroupResponse = await apiSdk.getGroup(groupId)
+                const group: Group = await apiSdk.getGroup(groupId)
                 expect(group.id).toBe(groupId)
             })
         })

--- a/libs/api-sdk/src/invites.ts
+++ b/libs/api-sdk/src/invites.ts
@@ -1,5 +1,5 @@
 import { request } from "@bandada/utils"
-import { InviteResponse } from "./types"
+import { Invite } from "./types"
 
 const url = "/invites"
 
@@ -11,7 +11,7 @@ const url = "/invites"
 export async function getInvite(
     config: object,
     inviteCode: string
-): Promise<InviteResponse> {
+): Promise<Invite> {
     const requestUrl = `${url}/${inviteCode}`
 
     const invite = await request(requestUrl, config)

--- a/libs/api-sdk/src/types/index.ts
+++ b/libs/api-sdk/src/types/index.ts
@@ -43,7 +43,7 @@ type GroupSummary = {
     updatedAt: Date
 }
 
-export type InviteResponse = {
+export type Invite = {
     code: string
     isRedeemed: boolean
     createdAt: Date

--- a/libs/api-sdk/src/types/index.ts
+++ b/libs/api-sdk/src/types/index.ts
@@ -38,9 +38,7 @@ type Group = {
     adminId: string
     treeDepth: number
     fingerprintDuration: number
-    credentials: Credential
-    apiEnabled: boolean
-    apiKey: string
+    credentials: Credential | null
     createdAt: Date
     updatedAt: Date
 }

--- a/libs/api-sdk/src/types/index.ts
+++ b/libs/api-sdk/src/types/index.ts
@@ -1,4 +1,7 @@
-import { ApiKeyActions } from "@bandada/utils"
+export type Credential = {
+    id: string
+    criteria: Record<string, any>
+}
 
 export type GroupResponse = {
     id: string
@@ -10,10 +13,7 @@ export type GroupResponse = {
     fingerprintDuration: number
     createdAt: Date
     members: string[]
-    credentials: {
-        id: string
-        criteria: Record<string, any>
-    }
+    credentials: Credential
 }
 
 export type GroupRequest = {
@@ -21,21 +21,14 @@ export type GroupRequest = {
     description: string
     treeDepth: number
     fingerprintDuration: number
-    id?: string
-    credentials?: {
-        id: string
-        criteria: Record<string, any>
-    }
+    credentials?: Credential
 }
 
 export type GroupUpdateRequest = {
     description: string
     treeDepth: number
     fingerprintDuration: number
-    credentials?: {
-        id: string
-        criteria: Record<string, any>
-    }
+    credentials?: Credential
 }
 
 type Group = {
@@ -45,10 +38,7 @@ type Group = {
     adminId: string
     treeDepth: number
     fingerprintDuration: number
-    credentials: {
-        id: string
-        criteria: Record<string, any>
-    }
+    credentials: Credential
     apiEnabled: boolean
     apiKey: string
     createdAt: Date

--- a/libs/api-sdk/src/types/index.ts
+++ b/libs/api-sdk/src/types/index.ts
@@ -3,7 +3,7 @@ export type Credential = {
     criteria: Record<string, any>
 }
 
-export type GroupResponse = {
+export type Group = {
     id: string
     name: string
     description: string
@@ -13,10 +13,10 @@ export type GroupResponse = {
     fingerprintDuration: number
     createdAt: Date
     members: string[]
-    credentials: Credential
+    credentials: Credential | null
 }
 
-export type GroupRequest = {
+export type GroupCreationDetails = {
     name: string
     description: string
     treeDepth: number
@@ -24,14 +24,14 @@ export type GroupRequest = {
     credentials?: Credential
 }
 
-export type GroupUpdateRequest = {
+export type GroupUpdateDetails = {
     description: string
     treeDepth: number
     fingerprintDuration: number
     credentials?: Credential
 }
 
-type Group = {
+type GroupSummary = {
     id: string
     name: string
     description: string
@@ -47,7 +47,7 @@ export type InviteResponse = {
     code: string
     isRedeemed: boolean
     createdAt: Date
-    group: Group
+    group: GroupSummary
     groupName: string
     groupId: string
 }


### PR DESCRIPTION
## Description

### Changes with this PR

#### API SDK 

- Fix `createGroup` and `createGroups` functions request. Now the right data object is sent in the `createGroups` request. 

- If the credentials parameter is undefined, it will be set to null in the server. 

- The group id is no longer part of the parameters to create a group, the group ids will be managed on the server.

- Update type names: Add clearer type names.

- Update Readme file to reflect the new changes in the Bandada API.

- Update some variable names and code refactoring.


## Related Issue

Closes #466 
Closes #467

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No
