### PR TITLE
Missing `return` statements for removeGroup(s) API SDK methods

### DIFF
--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -120,14 +120,20 @@ export class GroupsController {
 
         if (apiKey) {
             await this.groupsService.removeGroupsWithAPIKey(groupIds, apiKey)
-        } else if (req.session.adminId) {
+
+            return
+        }
+
+        if (req.session.adminId) {
             await this.groupsService.removeGroupsManually(
                 groupIds,
                 req.session.adminId
             )
-        } else {
-            throw new NotImplementedException()
+
+            return
         }
+
+        throw new NotImplementedException()
     }
 
     @Delete(":group")
@@ -145,14 +151,19 @@ export class GroupsController {
 
         if (apiKey) {
             await this.groupsService.removeGroupWithAPIKey(groupId, apiKey)
-        } else if (req.session.adminId) {
+
+            return
+        }
+        if (req.session.adminId) {
             await this.groupsService.removeGroupManually(
                 groupId,
                 req.session.adminId
             )
-        } else {
-            throw new NotImplementedException()
+
+            return
         }
+
+        throw new NotImplementedException()
     }
 
     @Patch()

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -133,7 +133,7 @@ export async function updateGroups(
     apiKey: string
 ): Promise<Array<Group>> {
     const newConfig: any = {
-        method: "put",
+        method: "patch",
         data: {
             groupIds,
             groupsInfo: groupsUpdateDetails


### PR DESCRIPTION

## Related Issue
fix #482 
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
