### PR TITLE
Avoid wrong `return` in removeGroup(s) API SDK methods

### DIFF
--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -130,7 +130,7 @@ export default class ApiSdk {
      * @returns undefined.
      */
     async removeGroup(groupId: string, apiKey: string): Promise<void> {
-        return removeGroup(this._config, groupId, apiKey)
+        await removeGroup(this._config, groupId, apiKey)
     }
 
     /**
@@ -140,7 +140,7 @@ export default class ApiSdk {
      * @returns undefined.
      */
     async removeGroups(groupIds: Array<string>, apiKey: string): Promise<void> {
-        return removeGroups(this._config, groupIds, apiKey)
+        await removeGroups(this._config, groupIds, apiKey)
     }
 
     /**

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -61,9 +61,7 @@ export async function removeGroup(
 
     newConfig.headers["x-api-key"] = apiKey
 
-    const req = await request(requestUrl, newConfig)
-
-    return req
+    await request(requestUrl, newConfig)
 }
 
 /**
@@ -86,9 +84,7 @@ export async function removeGroups(
 
     newConfig.headers["x-api-key"] = apiKey
 
-    const req = await request(url, newConfig)
-
-    return req
+    await request(url, newConfig)
 }
 
 /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR aims to fix the `BAD_RESPONSE` (500 - internal server error) caused by the wrong return statement.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
