### PR TITLE
Missing cascade remove for invites preventing deletion of groups

### DIFF
--- a/apps/api/src/app/groups/entities/group.entity.ts
+++ b/apps/api/src/app/groups/entities/group.entity.ts
@@ -11,6 +11,7 @@ import {
 } from "typeorm"
 import { OAuthAccount } from "../../credentials/entities/credentials-account.entity"
 import { Member } from "./member.entity"
+import { Invite } from "../../invites/entities/invite.entity"
 
 @Entity("groups")
 export class Group {
@@ -46,6 +47,11 @@ export class Group {
         }
     })
     members: Member[]
+
+    @OneToMany(() => Invite, (invite) => invite.group, {
+        cascade: ["remove"]
+    })
+    invites: Invite[]
 
     @OneToMany(() => OAuthAccount, (account) => account.group, {
         cascade: ["insert"]


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
The missing `cascade: ["remove"]` on Group entity for Invite entities was preventing the group to be deleted for the following error.

`QueryFailedError: update or delete on table "groups" violates foreign key constraint "invites_group_id_fkey" on table "invites"`
<!--- Describe your changes in detail -->


<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
