### PR TITLE
refactor: patch @semaphore-protocol/data to return result sorted by timestamp

### DIFF
--- a/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch
+++ b/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 614a9093f82e9ae8e9219b65af0a8e93ea992560..f35cadc1c3623e2209c261ddde6c678442079522 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1137,7 +1137,7 @@ var SemaphoreSubgraph = /** @class */ (function () {
+                                 filterFragments.push("timestamp_lte: \"".concat(jsDateToGraphqlDate(timestampLte), "\""));
+                             }
+                             if (filterFragments.length > 0) {
+-                                filtersQuery = "(where: {".concat(filterFragments.join(", "), "})");
++																filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
+                             }
+                         }
+                         config = {
+diff --git a/dist/index.node.js b/dist/index.node.js
+index 29640ebef31511af5ee5ff7e970c74e1fa0bc98e..14617cb0dab0fc92de298b6e572a70215d36bf43 100644
+--- a/dist/index.node.js
++++ b/dist/index.node.js
+@@ -1145,7 +1145,7 @@ var SemaphoreSubgraph = /** @class */ (function () {
+                                 filterFragments.push("timestamp_lte: \"".concat(jsDateToGraphqlDate(timestampLte), "\""));
+                             }
+                             if (filterFragments.length > 0) {
+-                                filtersQuery = "(where: {".concat(filterFragments.join(", "), "})");
++																filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
+                             }
+                         }
+                         config = {

--- a/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch
+++ b/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch
@@ -7,7 +7,7 @@ index 614a9093f82e9ae8e9219b65af0a8e93ea992560..f35cadc1c3623e2209c261ddde6c6784
                              }
                              if (filterFragments.length > 0) {
 -                                filtersQuery = "(where: {".concat(filterFragments.join(", "), "})");
-+																filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
++								 filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
                              }
                          }
                          config = {
@@ -20,7 +20,7 @@ index 29640ebef31511af5ee5ff7e970c74e1fa0bc98e..14617cb0dab0fc92de298b6e572a7021
                              }
                              if (filterFragments.length > 0) {
 -                                filtersQuery = "(where: {".concat(filterFragments.join(", "), "})");
-+																filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
++								 filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
                              }
                          }
                          config = {

--- a/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch
+++ b/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch
@@ -7,7 +7,7 @@ index 614a9093f82e9ae8e9219b65af0a8e93ea992560..f35cadc1c3623e2209c261ddde6c6784
                              }
                              if (filterFragments.length > 0) {
 -                                filtersQuery = "(where: {".concat(filterFragments.join(", "), "})");
-+								 filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
++								                 filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
                              }
                          }
                          config = {
@@ -20,7 +20,7 @@ index 29640ebef31511af5ee5ff7e970c74e1fa0bc98e..14617cb0dab0fc92de298b6e572a7021
                              }
                              if (filterFragments.length > 0) {
 -                                filtersQuery = "(where: {".concat(filterFragments.join(", "), "})");
-+								 filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
++								                 filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
                              }
                          }
                          config = {

--- a/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch
+++ b/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch
@@ -7,7 +7,7 @@ index 614a9093f82e9ae8e9219b65af0a8e93ea992560..f35cadc1c3623e2209c261ddde6c6784
                              }
                              if (filterFragments.length > 0) {
 -                                filtersQuery = "(where: {".concat(filterFragments.join(", "), "})");
-+								                 filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
++                                filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
                              }
                          }
                          config = {
@@ -20,7 +20,7 @@ index 29640ebef31511af5ee5ff7e970c74e1fa0bc98e..14617cb0dab0fc92de298b6e572a7021
                              }
                              if (filterFragments.length > 0) {
 -                                filtersQuery = "(where: {".concat(filterFragments.join(", "), "})");
-+								                 filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
++                                filtersQuery = "(orderBy:timestamp, orderDirection:desc, where: {".concat(filterFragments.join(", "), "})");
                              }
                          }
                          config = {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -18,7 +18,7 @@
         "@emotion/styled": "^11.10.6",
         "@fontsource-variable/unbounded": "^5.0.5",
         "@rainbow-me/rainbowkit": "^0.12.8",
-        "@semaphore-protocol/data": "3.10.0",
+        "@semaphore-protocol/data": "patch:@semaphore-protocol/data@npm%3A3.10.0#~/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch",
         "ethers": "5.5.1",
         "framer-motion": "^10.0.1",
         "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7440,6 +7440,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@semaphore-protocol/data@patch:@semaphore-protocol/data@npm%3A3.10.0#~/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch":
+  version: 3.10.0
+  resolution: "@semaphore-protocol/data@patch:@semaphore-protocol/data@npm%3A3.10.0#~/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch::version=3.10.0&hash=a89166"
+  dependencies:
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    axios: "npm:^0.27.2"
+  checksum: 10/9da8fde3d53db4a4b6abf712e35cf1ec1438860eb92170c56a13b4a58ccef0d4eb7df3ab7d470d6ecbf255e5704f0556b71e593580e625142fa01abbbfc1c9b3
+  languageName: node
+  linkType: hard
+
 "@semaphore-protocol/group@npm:3.10.0":
   version: 3.10.0
   resolution: "@semaphore-protocol/group@npm:3.10.0"
@@ -13955,7 +13966,7 @@ __metadata:
     "@emotion/styled": "npm:^11.10.6"
     "@fontsource-variable/unbounded": "npm:^5.0.5"
     "@rainbow-me/rainbowkit": "npm:^0.12.8"
-    "@semaphore-protocol/data": "npm:3.10.0"
+    "@semaphore-protocol/data": "patch:@semaphore-protocol/data@npm%3A3.10.0#~/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch"
     "@types/react": "npm:^18.0.27"
     "@types/react-dom": "npm:^18.0.10"
     "@vitejs/plugin-react": "npm:^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7442,12 +7442,12 @@ __metadata:
 
 "@semaphore-protocol/data@patch:@semaphore-protocol/data@npm%3A3.10.0#~/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch":
   version: 3.10.0
-  resolution: "@semaphore-protocol/data@patch:@semaphore-protocol/data@npm%3A3.10.0#~/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch::version=3.10.0&hash=a89166"
+  resolution: "@semaphore-protocol/data@patch:@semaphore-protocol/data@npm%3A3.10.0#~/.yarn/patches/@semaphore-protocol-data-npm-3.10.0-48e6c0f59e.patch::version=3.10.0&hash=ea766a"
   dependencies:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     axios: "npm:^0.27.2"
-  checksum: 10/9da8fde3d53db4a4b6abf712e35cf1ec1438860eb92170c56a13b4a58ccef0d4eb7df3ab7d470d6ecbf255e5704f0556b71e593580e625142fa01abbbfc1c9b3
+  checksum: 10/c760b945d59219776cb5201dedcae5390d4cb360487c6ff5b752d0058b43753318f941b4f3a1e799d9f6871ad2535a72a5574242c034d0fdfdcaea8685bef658
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR aims to patch @semaphore-protocol/data so that `getGroups` in dashboard will return results sorted by creation time in descending method

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/bandada-infra/bandada/issues/433

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
