### PR TITLE
Removed the function call to getAdminInfo()

### DIFF
--- a/apps/dashboard/src/components/api-key.tsx
+++ b/apps/dashboard/src/components/api-key.tsx
@@ -95,7 +95,7 @@ export default function ApiKeyComponent({
                     "Successfully refreshed",
                     "success"
                 )
-                getAdminInfo()
+                //getAdminInfo()
             }
         }
     }
@@ -136,7 +136,7 @@ export default function ApiKeyComponent({
                         ? "API key has been enabled."
                         : "API key has been disabled."
             }
-            getAdminInfo()
+            //getAdminInfo()
             showToast(toastTitle, toastDescription, "success")
         }
     }

--- a/apps/dashboard/src/components/api-key.tsx
+++ b/apps/dashboard/src/components/api-key.tsx
@@ -95,7 +95,6 @@ export default function ApiKeyComponent({
                     "Successfully refreshed",
                     "success"
                 )
-                //getAdminInfo()
             }
         }
     }
@@ -136,7 +135,6 @@ export default function ApiKeyComponent({
                         ? "API key has been enabled."
                         : "API key has been disabled."
             }
-            //getAdminInfo()
             showToast(toastTitle, toastDescription, "success")
         }
     }


### PR DESCRIPTION
## Description
As the functions handleRefresh() and toggleIsEnabled() were calling the function getAdminInfo() unnecessarily despite of the information already being present in the frontend. So, removed the function call to getAdminInfo()

Ran the unit tests and tested the dashboard application as well.

## Related Issue

#465 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
