### PR TITLE
chore: update dashboard url

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The applications will be deployed at the following URLs without any changes to t
 | App                | Development           | Production                     | Staging                                |
 | ------------------ | --------------------- | ------------------------------ | -------------------------------------- |
 | Bandada API        | http://localhost:3000 | https://api.bandada.pse.dev    | https://api-staging.bandada.pse.dev    |
-| Bandada Dashboard  | http://localhost:3001 | https://bandada.pse.dev        | https://staging.bandada.pse.dev        |
+| Bandada Dashboard  | http://localhost:3001 | https://app.bandada.pse.dev    | https://staging.bandada.pse.dev        |
 | Bandada Client App | http://localhost:3002 | https://client.bandada.pse.dev | https://client-staging.bandada.pse.dev |
 
 ## 🛠 Installation

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The applications will be deployed at the following URLs without any changes to t
 | App                | Development           | Production                     | Staging                                |
 | ------------------ | --------------------- | ------------------------------ | -------------------------------------- |
 | Bandada API        | http://localhost:3000 | https://api.bandada.pse.dev    | https://api-staging.bandada.pse.dev    |
-| Bandada Dashboard  | http://localhost:3001 | https://app.bandada.pse.dev    | https://staging.bandada.pse.dev        |
+| Bandada Dashboard  | http://localhost:3001 | https://app.bandada.pse.dev    | https://app-staging.bandada.pse.dev    |
 | Bandada Client App | http://localhost:3002 | https://client.bandada.pse.dev | https://client-staging.bandada.pse.dev |
 
 ## 🛠 Installation

--- a/apps/client/.env.production
+++ b/apps/client/.env.production
@@ -1,4 +1,4 @@
 # This file contains build time variables for prod env.
 
 VITE_API_URL=https://api.bandada.pse.dev
-VITE_DASHBOARD_URL=https://bandada.pse.dev
+VITE_DASHBOARD_URL=https://app.bandada.pse.dev

--- a/apps/client/.env.staging
+++ b/apps/client/.env.staging
@@ -1,4 +1,4 @@
 # This file contains build time variables for staging env.
 
 VITE_API_URL=https://api-staging.bandada.pse.dev
-VITE_DASHBOARD_URL=https://staging.bandada.pse.dev
+VITE_DASHBOARD_URL=https://app-staging.bandada.pse.dev

--- a/apps/dashboard/.env.production
+++ b/apps/dashboard/.env.production
@@ -6,4 +6,4 @@ VITE_CLIENT_INVITES_URL=https://client.bandada.pse.dev?inviteCode=\
 VITE_ETHEREUM_NETWORK=sepolia
 VITE_GITHUB_CLIENT_ID=6ccd7b93e84260e353f9
 VITE_TWITTER_CLIENT_ID=NV82Mm85NWlSZ1llZkpLMl9vN3A6MTpjaQ
-VITE_TWITTER_REDIRECT_URI=https://bandada.pse.dev/credentials
+VITE_TWITTER_REDIRECT_URI=https://app.bandada.pse.dev/credentials

--- a/apps/dashboard/.env.staging
+++ b/apps/dashboard/.env.staging
@@ -6,4 +6,4 @@ VITE_CLIENT_INVITES_URL=https://client-staging.bandada.pse.dev?inviteCode=\
 VITE_ETHEREUM_NETWORK=sepolia
 VITE_GITHUB_CLIENT_ID=6ccd7b93e84260e353f9
 VITE_TWITTER_CLIENT_ID=NV82Mm85NWlSZ1llZkpLMl9vN3A6MTpjaQ
-VITE_TWITTER_REDIRECT_URI=https://staging.bandada.pse.dev/credentials
+VITE_TWITTER_REDIRECT_URI=https://app-staging.bandada.pse.dev/credentials

--- a/apps/dashboard/src/components/navbar.tsx
+++ b/apps/dashboard/src/components/navbar.tsx
@@ -37,7 +37,7 @@ export default function NavBar(): JSX.Element {
                 backgroundRepeat="no-repeat"
                 backgroundSize="450px"
             >
-                <a href="https://bandada.pse.dev">
+                <a href="https://app.bandada.pse.dev">
                     <HStack spacing="1">
                         <Image
                             src={icon1Image}

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -63,7 +63,7 @@ const config: Config = {
             },
             items: [
                 {
-                    href: "https://bandada.pse.dev",
+                    href: "https://app.bandada.pse.dev",
                     label: "App",
                     position: "right"
                 },
@@ -104,7 +104,7 @@ const config: Config = {
                     items: [
                         {
                             label: "App",
-                            href: "https://bandada.pse.dev"
+                            href: "https://app.bandada.pse.dev"
                         },
                         {
                             label: "API",


### PR DESCRIPTION
## Description

The dashboard url will be `app.bandada.pse.dev` instead of `bandada.pse.dev` in production and `app-staging.bandada.pse.dev` instead of `staging.bandada.pse.dev` in staging.

## Related Issue

Closes #520

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No

