### PR TITLE
feat(api,api-sdk): add getGroupsByAdminId() and getGroupsByMemberId()

### DIFF
--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -39,6 +39,7 @@ export class GroupsController {
 
     @Get()
     @ApiQuery({ name: "adminId", required: false, type: String })
+    @ApiQuery({ name: "memberId", required: false, type: String })
     @ApiOperation({ description: "Returns the list of groups." })
     @ApiCreatedResponse({ type: Group, isArray: true })
     async getGroups(

--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -41,8 +41,11 @@ export class GroupsController {
     @ApiQuery({ name: "adminId", required: false, type: String })
     @ApiOperation({ description: "Returns the list of groups." })
     @ApiCreatedResponse({ type: Group, isArray: true })
-    async getGroups(@Query("adminId") adminId: string) {
-        const groups = await this.groupsService.getGroups({ adminId })
+    async getGroups(
+        @Query("adminId") adminId: string,
+        @Query("memberId") memberId: string
+    ) {
+        const groups = await this.groupsService.getGroups({ adminId, memberId })
         const groupIds = groups.map((group) => group.id)
         const fingerprints = await this.groupsService.getFingerprints(groupIds)
 

--- a/apps/api/src/app/groups/groups.service.test.ts
+++ b/apps/api/src/app/groups/groups.service.test.ts
@@ -222,6 +222,33 @@ describe("GroupsService", () => {
 
             expect(result).toHaveLength(1)
         })
+
+        it("Should return a list of groups by member", async () => {
+            const { id: _groupId } = await groupsService.createGroup(
+                {
+                    name: "MemberGroup",
+                    description: "This is a description",
+                    treeDepth: 16,
+                    fingerprintDuration: 3600
+                },
+                "admin"
+            )
+
+            const invite = await invitesService.createInvite(
+                { groupId: _groupId },
+                "admin"
+            )
+
+            await groupsService.joinGroup(_groupId, "123456", {
+                inviteCode: invite.code
+            })
+
+            const result = await groupsService.getGroups({
+                memberId: "123456"
+            })
+
+            expect(result).toHaveLength(1)
+        })
     })
 
     describe("# getGroup", () => {

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -811,11 +811,25 @@ export class GroupsService {
      * Returns a list of groups.
      * @returns List of existing groups.
      */
-    async getGroups(filters?: { adminId: string }): Promise<Group[]> {
-        const where = []
+    async getGroups(filters?: {
+        adminId?: string
+        memberId?: string
+    }): Promise<Group[]> {
+        let where = {}
 
         if (filters?.adminId) {
-            where.push({ adminId: filters.adminId })
+            where = {
+                adminId: filters.adminId
+            }
+        }
+
+        if (filters?.memberId) {
+            where = {
+                members: {
+                    id: filters.memberId
+                },
+                ...where
+            }
         }
 
         return this.groupRepository.find({

--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -233,6 +233,29 @@ Returns the list of groups.
 const groups = await apiSdk.getGroups()
 ```
 
+## Get groups by admin id
+
+\# **getGroupsByAdminId**(): _Promise\<Group[]>_
+
+Returns the list of groups by admin id.
+
+```ts
+const adminId =
+    "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847"
+const groups = await apiSdk.getGroupsByAdminId(adminId)
+```
+
+## Get groups by member id
+
+\# **getGroupsByMemberId**(): _Promise\<Group[]>_
+
+Returns the list of groups by member id.
+
+```ts
+const memberId = "1"
+const groups = await apiSdk.getGroupsByMemberId(memberId)
+```
+
 ## Is group member
 
 \# **isGroupMember**(): _Promise\<boolean>_

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -256,6 +256,29 @@ Returns the list of groups.
 const groups = await apiSdk.getGroups()
 ```
 
+## Get groups by admin id
+
+\# **getGroupsByAdminId**(): _Promise\<Group[]>_
+
+Returns the list of groups by admin id.
+
+```ts
+const adminId =
+    "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847"
+const groups = await apiSdk.getGroupsByAdminId(adminId)
+```
+
+## Get groups by member id
+
+\# **getGroupsByMemberId**(): _Promise\<Group[]>_
+
+Returns the list of groups by member id.
+
+```ts
+const memberId = "1"
+const groups = await apiSdk.getGroupsByMemberId(memberId)
+```
+
 ## Is group member
 
 \# **isGroupMember**(): _Promise\<boolean>_

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -20,7 +20,9 @@ import {
     addMembersByApiKey,
     addMemberByInviteCode,
     removeMemberByApiKey,
-    removeMembersByApiKey
+    removeMembersByApiKey,
+    getGroupsByAdminId,
+    getGroupsByMemberId
 } from "./groups"
 import { createInvite, getInvite } from "./invites"
 
@@ -81,6 +83,28 @@ export default class ApiSdk {
      */
     async getGroups(): Promise<Group[]> {
         const groups = await getGroups(this._config)
+
+        return groups
+    }
+
+    /**
+     * Returns the list of groups by admin id.
+     * @param adminId Admin id.
+     * @returns List of groups by admin id.
+     */
+    async getGroupsByAdminId(adminId: string): Promise<Group[]> {
+        const groups = await getGroupsByAdminId(this._config, adminId)
+
+        return groups
+    }
+
+    /**
+     * Returns the list of groups by member id.
+     * @param memberId Member id.
+     * @returns List of groups by member id.
+     */
+    async getGroupsByMemberId(memberId: string): Promise<Group[]> {
+        const groups = await getGroupsByMemberId(this._config, memberId)
 
         return groups
     }

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -19,6 +19,48 @@ export async function getGroups(config: object): Promise<Group[]> {
 }
 
 /**
+ * Returns the list of groups by admin id.
+ * @param adminId Admin id.
+ * @returns List of groups by admin id.
+ */
+export async function getGroupsByAdminId(
+    config: object,
+    adminId: string
+): Promise<Group[]> {
+    const requestUrl = `${url}?adminId=${adminId}`
+
+    const groups = await request(requestUrl, config)
+
+    groups.map((group: any) => ({
+        ...group,
+        credentials: JSON.parse(group.credentials)
+    }))
+
+    return groups
+}
+
+/**
+ * Returns the list of groups by member id.
+ * @param memberId Member id.
+ * @returns List of groups by member id.
+ */
+export async function getGroupsByMemberId(
+    config: object,
+    memberId: string
+): Promise<Group[]> {
+    const requestUrl = `${url}?memberId=${memberId}`
+
+    const groups = await request(requestUrl, config)
+
+    groups.map((group: any) => ({
+        ...group,
+        credentials: JSON.parse(group.credentials)
+    }))
+
+    return groups
+}
+
+/**
  * Creates one or more groups with the provided details.
  * @param groupsCreationDetails Data to create the groups.
  * @param apiKey API Key of the admin.

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -345,6 +345,62 @@ describe("Bandada API SDK", () => {
                 expect(groups).toHaveLength(1)
             })
         })
+        describe("#getGroupsByAdminId", () => {
+            it("Should return all groups by admin id", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: [],
+                            credentials: null
+                        }
+                    ])
+                )
+
+                const adminId =
+                    "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847"
+
+                apiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups: Group[] = await apiSdk.getGroupsByAdminId(adminId)
+                expect(groups).toHaveLength(1)
+                groups.forEach((group: Group) => {
+                    expect(group.admin).toBe(adminId)
+                })
+            })
+        })
+        describe("#getGroupsByMemberId", () => {
+            it("Should return all groups by member id", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: ["1"],
+                            credentials: null
+                        }
+                    ])
+                )
+
+                const memberId = "1"
+
+                apiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups: Group[] = await apiSdk.getGroupsByMemberId(
+                    memberId
+                )
+                expect(groups).toHaveLength(1)
+            })
+        })
         describe("#getGroup", () => {
             it("Should return a group", async () => {
                 requestMocked.mockImplementationOnce(() =>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added new api-sdk features that allows users to get groups based on adminId and memberId.

<!--- Describe your changes in detail -->

## Related Issue

Closes #493

Move PR #519 from `dev` branch to `main` branch

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Changed `where` from `array` to `object` so that it will return results for `AND` instead of `OR` when both `adminId` and `memberId` is present in the query.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

