### PR TITLE
Update configs

### DIFF
--- a/libs/credentials/package.json
+++ b/libs/credentials/package.json
@@ -6,7 +6,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/libs/hardhat/package.json
+++ b/libs/hardhat/package.json
@@ -6,7 +6,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -6,7 +6,8 @@
     "main": "dist/index.node.js",
     "exports": {
         "import": "./dist/index.mjs",
-        "require": "./dist/index.node.js"
+        "require": "./dist/index.node.js",
+        "types": "./dist/types/index.d.ts"
     },
     "types": "dist/types/index.d.ts",
     "files": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "private": true,
     "scripts": {
         "start": "yarn workspaces foreach --exclude bandada-docs -A -pi run start",
-        "dev": "yarn workspaces foreach --exclude contracts -A -pi run dev",
+        "dev": "yarn workspaces foreach --exclude contracts --exclude bandada-website -A -pi run dev",
         "test": "jest && yarn workspace contracts test",
         "test:coverage": "yarn test:jest:coverage && yarn test:contracts:coverage",
         "test:jest:coverage": "jest --coverage",


### PR DESCRIPTION
## Description

This PR excludes the website when running `yarn dev` in the main project folder. It also exports the types for the packages: `credentials`, `hardhat` and `utils`.

## Related Issue

Closes https://github.com/bandada-infra/bandada/issues/525

Closes https://github.com/bandada-infra/bandada/issues/517

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
