### PR TITLE
feat(api-sdk): add joinCredentialGroup()

### DIFF
--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -377,3 +377,27 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 
 const invite = await apiSdk.getInvite(inviteCode)
 ```
+
+## Get credential group join URL
+
+\# **getCredentialGroupJoinUrl**(): _string_
+
+Returns a custom URL string for joining a credential group.
+
+```ts
+import { DashboardUrl } from "@bandada/api-sdk"
+
+const dashboardUrl = DashboardUrl.DEV
+const groupId = "10402173435763029700781503965100"
+const commitment = "1"
+const providerName = "github"
+const redirectUri = "http://localhost:3003"
+
+const url = apiSdk.getCredentialGroupJoinUrl(
+    dashboardUrl,
+    groupId,
+    commitment,
+    providerName,
+    redirectUri
+)
+```

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -403,7 +403,7 @@ const invite = await apiSdk.getInvite(inviteCode)
 
 ## Join credential group
 
-\# **joinCredentialGroup**(): _string_
+\# **getCredentialGroupJoinUrl**(): _string_
 
 Returns a custom URL string for joining a credential group.
 
@@ -414,7 +414,7 @@ const commitment = "1"
 const providerName = "github"
 const redirectUri = "http://localhost:3003"
 
-const url = apiSdk.joinCredentialGroup(
+const url = apiSdk.getCredentialGroupJoinUrl(
     baseUrl,
     groupId,
     commitment,

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -405,7 +405,7 @@ const invite = await apiSdk.getInvite(inviteCode)
 
 \# **joinCredentialGroup**(): _string_
 
-Returns a custom URL string for joining credential group.
+Returns a custom URL string for joining a credential group.
 
 ```ts
 const baseUrl = "http://localhost:3000"

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -400,3 +400,25 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 
 const invite = await apiSdk.getInvite(inviteCode)
 ```
+
+## Join credential group
+
+\# **joinCredentialGroup**(): _string_
+
+Returns a custom URL string for joining credential group.
+
+```ts
+const baseUrl = "http://localhost:3000"
+const groupId = "10402173435763029700781503965100"
+const commitment = "1"
+const providerName = "GITHUB"
+const redirectUri = "http://localhost:3003"
+
+const url = apiSdk.joinCredentialGroup(
+    baseUrl,
+    groupId,
+    commitment,
+    providerName,
+    redirectUri
+)
+```

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -401,7 +401,7 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const invite = await apiSdk.getInvite(inviteCode)
 ```
 
-## Join credential group
+## Get credential group join URL
 
 \# **getCredentialGroupJoinUrl**(): _string_
 

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -408,14 +408,16 @@ const invite = await apiSdk.getInvite(inviteCode)
 Returns a custom URL string for joining a credential group.
 
 ```ts
-const baseUrl = "http://localhost:3000"
+import { DashboardUrl } from "@bandada/api-sdk"
+
+const dashboardUrl = DashboardUrl.DEV
 const groupId = "10402173435763029700781503965100"
 const commitment = "1"
 const providerName = "github"
 const redirectUri = "http://localhost:3003"
 
 const url = apiSdk.getCredentialGroupJoinUrl(
-    baseUrl,
+    dashboardUrl,
     groupId,
     commitment,
     providerName,

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -411,7 +411,7 @@ Returns a custom URL string for joining a credential group.
 const baseUrl = "http://localhost:3000"
 const groupId = "10402173435763029700781503965100"
 const commitment = "1"
-const providerName = "GITHUB"
+const providerName = "github"
 const redirectUri = "http://localhost:3003"
 
 const url = apiSdk.joinCredentialGroup(

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -22,7 +22,8 @@ import {
     removeMemberByApiKey,
     removeMembersByApiKey,
     getGroupsByAdminId,
-    getGroupsByMemberId
+    getGroupsByMemberId,
+    joinCredentialGroup
 } from "./groups"
 import { createInvite, getInvite } from "./invites"
 
@@ -349,5 +350,32 @@ export default class ApiSdk {
         const invite = await getInvite(this._config, inviteCode)
 
         return invite
+    }
+
+    /**
+     * Generate a custom url for joining a credential group.
+     * @param baseUrl Base url.
+     * @param groupId Group id.
+     * @param commitment Identity commitment.
+     * @param providerName Group credential provider name.
+     * @param redirectUri Redirect uri.
+     * @returns Url string.
+     */
+    joinCredentialGroup(
+        baseUrl: string,
+        groupId: string,
+        commitment: string,
+        providerName: string,
+        redirectUri?: string
+    ) {
+        const url = joinCredentialGroup(
+            baseUrl,
+            groupId,
+            commitment,
+            providerName,
+            redirectUri
+        )
+
+        return url
     }
 }

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -367,7 +367,7 @@ export default class ApiSdk {
         commitment: string,
         providerName: string,
         redirectUri?: string
-    ) {
+    ): string {
         const url = joinCredentialGroup(
             baseUrl,
             groupId,

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -3,7 +3,8 @@ import {
     Group,
     Invite,
     GroupCreationDetails,
-    GroupUpdateDetails
+    GroupUpdateDetails,
+    DashboardUrl
 } from "./types"
 import checkParameter from "./checkParameter"
 import {
@@ -354,7 +355,7 @@ export default class ApiSdk {
 
     /**
      * Generate a custom url for joining a credential group.
-     * @param baseUrl Base url.
+     * @param dashboardUrl Dashboard base url.
      * @param groupId Group id.
      * @param commitment Identity commitment.
      * @param providerName Group credential provider name.
@@ -362,14 +363,14 @@ export default class ApiSdk {
      * @returns Url string.
      */
     getCredentialGroupJoinUrl(
-        baseUrl: string,
+        dashboardUrl: DashboardUrl,
         groupId: string,
         commitment: string,
         providerName: string,
         redirectUri?: string
     ): string {
         const url = getCredentialGroupJoinUrl(
-            baseUrl,
+            dashboardUrl,
             groupId,
             commitment,
             providerName,

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -23,7 +23,7 @@ import {
     removeMembersByApiKey,
     getGroupsByAdminId,
     getGroupsByMemberId,
-    joinCredentialGroup
+    getCredentialGroupJoinUrl
 } from "./groups"
 import { createInvite, getInvite } from "./invites"
 
@@ -361,14 +361,14 @@ export default class ApiSdk {
      * @param redirectUri Redirect uri.
      * @returns Url string.
      */
-    joinCredentialGroup(
+    getCredentialGroupJoinUrl(
         baseUrl: string,
         groupId: string,
         commitment: string,
         providerName: string,
         redirectUri?: string
     ): string {
-        const url = joinCredentialGroup(
+        const url = getCredentialGroupJoinUrl(
             baseUrl,
             groupId,
             commitment,

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -1,5 +1,10 @@
 import { request } from "@bandada/utils"
-import type { GroupCreationDetails, Group, GroupUpdateDetails } from "./types"
+import type {
+    GroupCreationDetails,
+    Group,
+    GroupUpdateDetails,
+    DashboardUrl
+} from "./types"
 
 const url = "/groups"
 
@@ -374,7 +379,7 @@ export async function removeMembersByApiKey(
 
 /**
  * Generate a custorm url for joining a credential group.
- * @param baseUrl Base url.
+ * @param dashboardUrl Dashboard url.
  * @param groupId Group id.
  * @param commitment Identity commitment.
  * @param providerName Group credential provider name.
@@ -382,13 +387,13 @@ export async function removeMembersByApiKey(
  * @returns Url string.
  */
 export function getCredentialGroupJoinUrl(
-    baseUrl: string,
+    dashboardUrl: DashboardUrl,
     groupId: string,
     commitment: string,
     providerName: string,
     redirectUri?: string
 ): string {
-    let resultUrl = `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}`
+    let resultUrl = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}`
 
     if (redirectUri) {
         resultUrl += `&redirect_uri=${redirectUri}?redirect=true`

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -371,3 +371,26 @@ export async function removeMembersByApiKey(
 
     await request(requestUrl, newConfig)
 }
+
+/**
+ * Generate a custorm url for joining a credential group.
+ * @param baseUrl Base url.
+ * @param groupId Group id.
+ * @param commitment Identity commitment.
+ * @param providerName Group credential provider name.
+ * @param redirectUri Redirect uri.
+ * @returns Url string.
+ */
+export function joinCredentialGroup(
+    baseUrl: string,
+    groupId: string,
+    commitment: string,
+    providerName: string,
+    redirectUri?: string
+) {
+    if (redirectUri) {
+        return `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}/groups?redirect=true`
+    }
+
+    return `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}`
+}

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -388,9 +388,11 @@ export function joinCredentialGroup(
     providerName: string,
     redirectUri?: string
 ): string {
+    let resultUrl = `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}`
+
     if (redirectUri) {
-        return `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}/groups?redirect=true`
+        resultUrl += `&redirect_uri=${redirectUri}?redirect=true`
     }
 
-    return `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}`
+    return resultUrl
 }

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -387,7 +387,7 @@ export function joinCredentialGroup(
     commitment: string,
     providerName: string,
     redirectUri?: string
-) {
+): string {
     if (redirectUri) {
         return `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}/groups?redirect=true`
     }

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -381,7 +381,7 @@ export async function removeMembersByApiKey(
  * @param redirectUri Redirect uri.
  * @returns Url string.
  */
-export function joinCredentialGroup(
+export function getCredentialGroupJoinUrl(
     baseUrl: string,
     groupId: string,
     commitment: string,

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -583,16 +583,16 @@ describe("Bandada API SDK", () => {
                 })
             })
 
-            describe("#joinCredentialGroup", () => {
+            describe("#getCredentialGroupJoinUrl", () => {
                 it("Should generate a custom url for joining a credential group", async () => {
                     const baseUrl = "http://localhost:3000"
                     const groupId = "10402173435763029700781503965100"
                     const commitment = "1"
-                    const providerName = "GITHUB"
+                    const providerName = "github"
                     const redirectUri = "http://localhost:3003"
 
                     apiSdk = new ApiSdk(SupportedUrl.DEV)
-                    const res = apiSdk.joinCredentialGroup(
+                    const res = apiSdk.getCredentialGroupJoinUrl(
                         baseUrl,
                         groupId,
                         commitment,
@@ -600,7 +600,7 @@ describe("Bandada API SDK", () => {
                         redirectUri
                     )
 
-                    const url = `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}/groups?redirect=true`
+                    const url = `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}?redirect=true`
 
                     expect(res).toBe(url)
                 })

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -5,7 +5,8 @@ import {
     Group,
     GroupUpdateDetails,
     Invite,
-    SupportedUrl
+    SupportedUrl,
+    DashboardUrl
 } from "./types"
 import checkParameter from "./checkParameter"
 
@@ -585,7 +586,7 @@ describe("Bandada API SDK", () => {
 
             describe("#getCredentialGroupJoinUrl", () => {
                 it("Should generate a custom url for joining a credential group", async () => {
-                    const baseUrl = "http://localhost:3000"
+                    const dashboardUrl = DashboardUrl.DEV
                     const groupId = "10402173435763029700781503965100"
                     const commitment = "1"
                     const providerName = "github"
@@ -593,14 +594,14 @@ describe("Bandada API SDK", () => {
 
                     apiSdk = new ApiSdk(SupportedUrl.DEV)
                     const res = apiSdk.getCredentialGroupJoinUrl(
-                        baseUrl,
+                        dashboardUrl,
                         groupId,
                         commitment,
                         providerName,
                         redirectUri
                     )
 
-                    const url = `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}?redirect=true`
+                    const url = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}?redirect=true`
 
                     expect(res).toBe(url)
                 })

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -582,6 +582,29 @@ describe("Bandada API SDK", () => {
                     expect(res).toBeUndefined()
                 })
             })
+
+            describe("#joinCredentialGroup", () => {
+                it("Should generate a custom url for joining a credential group", async () => {
+                    const baseUrl = "http://localhost:3000"
+                    const groupId = "10402173435763029700781503965100"
+                    const commitment = "1"
+                    const providerName = "GITHUB"
+                    const redirectUri = "http://localhost:3003"
+
+                    apiSdk = new ApiSdk(SupportedUrl.DEV)
+                    const res = apiSdk.joinCredentialGroup(
+                        baseUrl,
+                        groupId,
+                        commitment,
+                        providerName,
+                        redirectUri
+                    )
+
+                    const url = `${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}/groups?redirect=true`
+
+                    expect(res).toBe(url)
+                })
+            })
         })
     })
     describe("Invites", () => {

--- a/libs/api-sdk/src/types/index.ts
+++ b/libs/api-sdk/src/types/index.ts
@@ -55,3 +55,9 @@ export enum SupportedUrl {
     PROD = "https://api.bandada.pse.dev",
     STAGING = "https://api-staging.bandada.pse.dev"
 }
+
+export enum DashboardUrl {
+    DEV = "http://localhost:3001",
+    PROD = "https://app.bandada.pse.dev",
+    STAGING = "https://app-staging.bandada.pse.dev"
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a new api-sdk function that allows users to generate a custom URL to join a credential group. 

This function takes in `baseUrl`, `groupId`, `commitment`, `providerName`, and an optional `redirectUri` as params and has 2 different returned URL, with and without `redirectUri`. Example:

With:
```ts
`${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}/groups?redirect=true`

```

Without:
```ts
`${baseUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}`
```

<!--- Describe your changes in detail -->

## Related Issue

Closes #513 

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

