### PR TITLE
Fix validate function in blockchain balance validator

### DIFF
--- a/libs/credentials/src/validators/blockchainBalance/index.test.ts
+++ b/libs/credentials/src/validators/blockchainBalance/index.test.ts
@@ -8,7 +8,9 @@ describe("BlockchainBalance", () => {
     }
 
     it("Should return true if an account has a balance greater than or equal to 10", async () => {
-        jsonRpcProviderMocked.getBalance.mockReturnValue(BigNumber.from("12000000000000000000"))
+        jsonRpcProviderMocked.getBalance.mockReturnValue(
+            BigNumber.from("12000000000000000000")
+        )
 
         const result = await validateCredentials(
             {
@@ -28,7 +30,9 @@ describe("BlockchainBalance", () => {
     })
 
     it("Should return true if an account has a balance greater than or equal to 10 using the block number", async () => {
-        jsonRpcProviderMocked.getBalance.mockReturnValue(BigNumber.from("12000000000000000000"))
+        jsonRpcProviderMocked.getBalance.mockReturnValue(
+            BigNumber.from("12000000000000000000")
+        )
 
         const result = await validateCredentials(
             {

--- a/libs/credentials/src/validators/blockchainBalance/index.test.ts
+++ b/libs/credentials/src/validators/blockchainBalance/index.test.ts
@@ -8,7 +8,7 @@ describe("BlockchainBalance", () => {
     }
 
     it("Should return true if an account has a balance greater than or equal to 10", async () => {
-        jsonRpcProviderMocked.getBalance.mockReturnValue(BigNumber.from(12))
+        jsonRpcProviderMocked.getBalance.mockReturnValue(BigNumber.from("12000000000000000000"))
 
         const result = await validateCredentials(
             {
@@ -28,7 +28,7 @@ describe("BlockchainBalance", () => {
     })
 
     it("Should return true if an account has a balance greater than or equal to 10 using the block number", async () => {
-        jsonRpcProviderMocked.getBalance.mockReturnValue(BigNumber.from(12))
+        jsonRpcProviderMocked.getBalance.mockReturnValue(BigNumber.from("12000000000000000000"))
 
         const result = await validateCredentials(
             {

--- a/libs/credentials/src/validators/blockchainBalance/index.ts
+++ b/libs/credentials/src/validators/blockchainBalance/index.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers"
+import { utils } from "ethers"
 import { BlockchainContext, Validator } from "../.."
 
 export type Criteria = {
@@ -38,13 +38,16 @@ const validator: Validator = {
                     ? criteria.blockNumber
                     : undefined
 
-            const balance = await (
+            const balanceWei = await (
                 context as BlockchainContext
             ).jsonRpcProvider.getBalance(
                 (context as BlockchainContext).address,
                 blockNumber
             )
-            return balance >= BigNumber.from(criteria.minBalance)
+
+            const balanceETH = utils.formatEther(balanceWei)
+            
+            return parseFloat(balanceETH) >= parseFloat(criteria.minBalance)
         }
         throw new Error("No address value found")
     }

--- a/libs/credentials/src/validators/blockchainBalance/index.ts
+++ b/libs/credentials/src/validators/blockchainBalance/index.ts
@@ -46,7 +46,7 @@ const validator: Validator = {
             )
 
             const balanceETH = utils.formatEther(balanceWei)
-            
+
             return parseFloat(balanceETH) >= parseFloat(criteria.minBalance)
         }
         throw new Error("No address value found")


### PR DESCRIPTION
## Description

The balance returned by the jsonRpcProvider is Wei and it should be converted to Ethers so that people can work with Ethers instead of Wei.

## Related Issue

Closes #532

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
