### PR TITLE
#395: Implement off-chain group information download

### DIFF
--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -517,7 +517,7 @@ ${memberIds.join("\n")}
                             <Text fontSize="20px">Download group</Text>
                             <Flex align="center" mt="2">
                                 <Text my="10px" fontWeight="400">
-                                    Get the group&apos; data JSON format.
+                                    Get the group&apos;s data JSON format.
                                 </Text>
                                 <Spacer />
                                 <Button

--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -246,30 +246,30 @@ ${memberIds.join("\n")}
     }
 
     const handleDownload = async () => {
-        if (!_group) return;
+        if (!_group) return
 
         try {
-            const response = await bandadaApi.getGroup(_group.id);
+            const response = await bandadaApi.getGroup(_group.id)
             if (response) {
-                const json = JSON.stringify(response, null, 2);
-                const blob = new Blob([json], { type: 'application/json' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = `${_group.name}.json`;
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-                URL.revokeObjectURL(url);
+                const json = JSON.stringify(response, null, 2)
+                const blob = new Blob([json], { type: "application/json" })
+                const url = URL.createObjectURL(blob)
+                const a = document.createElement("a")
+                a.href = url
+                a.download = `${_group.name}.json`
+                document.body.appendChild(a)
+                a.click()
+                document.body.removeChild(a)
+                URL.revokeObjectURL(url)
             }
         } catch (error) {
-            console.error("Failed to download group data:", error);
+            console.error("Failed to download group data:", error)
             toast({
                 title: "Error",
                 description: "Failed to download group data.",
                 status: "error",
                 duration: 3000
-            });
+            })
         }
     }
     let credentialsId = ""
@@ -514,21 +514,21 @@ ${memberIds.join("\n")}
                             p="25px 30px 25px 30px"
                             borderRadius="8px"
                         >
-                        <Text fontSize="20px">Download group</Text>
-                        <Flex align="center" mt="2">
-                            <Text my="10px" fontWeight="400">
-                                Get the group's data in JSON format.
-                            </Text>
-                            <Spacer />
-                            <Button
-                                variant="solid"
-                                colorScheme="tertiary"
-                                onClick={handleDownload}
-                            >
-                                Download
-                            </Button>
-                        </Flex>
-                    </Box>
+                            <Text fontSize="20px">Download group</Text>
+                            <Flex align="center" mt="2">
+                                <Text my="10px" fontWeight="400">
+                                    Get the group&apos; data JSON format.
+                                </Text>
+                                <Spacer />
+                                <Button
+                                    variant="solid"
+                                    colorScheme="tertiary"
+                                    onClick={handleDownload}
+                                >
+                                    Download
+                                </Button>
+                            </Flex>
+                        </Box>
                     )}
                     {/* {groupType === "off-chain" &&
                         !_group.credentials &&

--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -17,6 +17,7 @@ import {
     MenuButton,
     MenuItem,
     MenuList,
+    Spacer,
     // Switch,
     Text,
     Tooltip,
@@ -242,6 +243,34 @@ ${memberIds.join("\n")}
 
     const handleDeselectAll = () => {
         setSelectedMembers([])
+    }
+
+    const handleDownload = async () => {
+        if (!_group) return;
+
+        try {
+            const response = await bandadaApi.getGroup(_group.id);
+            if (response) {
+                const json = JSON.stringify(response, null, 2);
+                const blob = new Blob([json], { type: 'application/json' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `${_group.name}.json`;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+            }
+        } catch (error) {
+            console.error("Failed to download group data:", error);
+            toast({
+                title: "Error",
+                description: "Failed to download group data.",
+                status: "error",
+                duration: 3000
+            });
+        }
     }
     let credentialsId = ""
     let credentialsCriteria = ""
@@ -478,6 +507,28 @@ ${memberIds.join("\n")}
                                 </>
                             )}
                         </Box>
+                    )}
+                    {_group.type === "off-chain" && isGroupAdmin && (
+                        <Box
+                            bgColor="balticSea.50"
+                            p="25px 30px 25px 30px"
+                            borderRadius="8px"
+                        >
+                        <Text fontSize="20px">Download group</Text>
+                        <Flex align="center" mt="2">
+                            <Text my="10px" fontWeight="400">
+                                Get the group's data in JSON format.
+                            </Text>
+                            <Spacer />
+                            <Button
+                                variant="solid"
+                                colorScheme="tertiary"
+                                onClick={handleDownload}
+                            >
+                                Download
+                            </Button>
+                        </Flex>
+                    </Box>
                     )}
                     {/* {groupType === "off-chain" &&
                         !_group.credentials &&


### PR DESCRIPTION
## Description

Added a box and button to the off-chain group page (/groups/off-chain/[]) to allow downloading of group information.

Change apps/dashborad/src/pages/group.tsx
- Added Download group box component
- added handleDownload function
- imported Spaser from chakura-ui

## Does this introduce a breaking change?

-   [ ] Yes
-   [✔︎] No

## Other information

<img width="1259" alt="スクリーンショット 2024-09-14 1 42 49" src="https://github.com/user-attachments/assets/2ad729d8-0421-4098-ab9b-4a433679e73f">
<img width="870" alt="スクリーンショット 2024-09-14 1 43 20" src="https://github.com/user-attachments/assets/0dfeb89a-e605-48ce-aa1c-623cdb71e003">

