### PR TITLE
feat: list all the credential groups

### DIFF
--- a/apps/dashboard/src/api/bandadaAPI.ts
+++ b/apps/dashboard/src/api/bandadaAPI.ts
@@ -40,9 +40,13 @@ export async function generateMagicLink(
  * @param adminId The admin id.
  * @returns The list of groups or null.
  */
-export async function getGroups(adminId: string): Promise<Group[] | null> {
+export async function getGroups(adminId?: string): Promise<Group[] | null> {
     try {
-        const groups = await request(`${API_URL}/groups/?adminId=${adminId}`)
+        const url = adminId
+            ? `${API_URL}/groups/?adminId=${adminId}`
+            : `${API_URL}/groups/`
+
+        const groups = await request(url)
 
         return groups.map((group: Group) => ({
             ...group,

--- a/apps/dashboard/src/pages/groups.tsx
+++ b/apps/dashboard/src/pages/groups.tsx
@@ -27,6 +27,7 @@ export default function GroupsPage(): JSX.Element {
     const { admin } = useContext(AuthContext)
     const [_isLoading, setIsLoading] = useState(false)
     const [_groups, setGroups] = useState<Group[]>([])
+    const [_allCredentialGroups, setAllCredentialGroups] = useState<Group[]>([])
     const [_searchField, setSearchField] = useState<string>("")
     const navigate = useNavigate()
 
@@ -35,6 +36,7 @@ export default function GroupsPage(): JSX.Element {
             if (admin) {
                 setIsLoading(true)
                 setGroups([])
+                setAllCredentialGroups([])
 
                 await Promise.all([
                     getOnchainGroups(admin.address).then((onchainGroups) => {
@@ -48,6 +50,14 @@ export default function GroupsPage(): JSX.Element {
                                 ...groups,
                                 ...offchainGroups
                             ])
+                        }
+                    }),
+                    getOffchainGroups().then((allOffchainGroups) => {
+                        if (allOffchainGroups) {
+                            const credentialGroups = allOffchainGroups.filter(
+                                (group) => group.credentials !== null
+                            )
+                            setAllCredentialGroups(credentialGroups)
                         }
                     })
                 ])
@@ -139,6 +149,52 @@ export default function GroupsPage(): JSX.Element {
                             .sort(
                                 (a, b) =>
                                     new Date(b.createdAt || "").getTime() - // Convert string to Date object
+                                    new Date(a.createdAt || "").getTime()
+                            )
+                            .map((group) => (
+                                <Link
+                                    key={group.id + group.name}
+                                    to={`/groups/${group.type}/${group.id}`}
+                                >
+                                    <GridItem>
+                                        <GroupCard {...group} />
+                                    </GridItem>
+                                </Link>
+                            ))}
+                    </Grid>
+                )}
+
+                <Box h="100px" />
+
+                <HStack justifyContent="space-between" width="100%">
+                    <Heading fontSize="40px" as="h1">
+                        All credential groups
+                    </Heading>
+                </HStack>
+
+                {_isLoading && (
+                    <Box pt="100px">
+                        <Spinner />
+                    </Box>
+                )}
+
+                {!_isLoading && _allCredentialGroups.length === 0 && (
+                    <Text fontSize="2xl" fontWeight="bold" pt="100px">
+                        No credential groups found
+                    </Text>
+                )}
+
+                {!_isLoading && _allCredentialGroups.length > 0 && (
+                    <Grid
+                        templateColumns="repeat(3, 1fr)"
+                        gap={10}
+                        w="100%"
+                        mt="60px"
+                    >
+                        {_allCredentialGroups
+                            .sort(
+                                (a, b) =>
+                                    new Date(b.createdAt || "").getTime() -
                                     new Date(a.createdAt || "").getTime()
                             )
                             .map((group) => (


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Updated the groups page on the dashboard to display all credential groups.

Change apps\dashboard\src\pages\groups.tsx

- Added a feature to get all credential groups.
- Added a component to display all credential groups.

Change apps\dashboard\src\api\bandadaAPI.ts

- Added an optional parameter to the `getGroups` method.
- Modified the method to return all groups when the parameter is omitted.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #323

## Does this introduce a breaking change?

-   [ ] Yes
-   [✔︎] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
![issue323](https://github.com/user-attachments/assets/48506123-0648-424f-a43f-c49c89bb3558)


