### PR TITLE
 replace deprecated polygon mumbai with polygon amoy  #534

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -24,10 +24,10 @@ TWITTER_CLIENT_ID=
 TWITTER_CLIENT_SECRET=
 
 # The network name must be the same as the id that appears in the `blockchainCredentialSupportedNetworks` list 
-# exported from the `@bandada/utils` package but with capital letters. E.g. polygon_mumbai would be POLYGON_MUMBAI.
+# exported from the `@bandada/utils` package but with capital letters. E.g. polygon_amoy would be POLYGON_AMOY.
 
 SEPOLIA_RPC_URL=
-POLYGON_MUMBAI_RPC_URL=
+POLYGON_AMOY_RPC_URL=
 OPTIMISM_SEPOLIA_RPC_URL=
 ARBITRUM_SEPOLIA_RPC_URL=
 AVALANCHE_C_CHAIN_FUJI_RPC_URL=

--- a/libs/utils/src/getSupportedNetworks.ts
+++ b/libs/utils/src/getSupportedNetworks.ts
@@ -6,8 +6,8 @@ export const blockchainCredentialSupportedNetworks: BlockchainNetwork[] = [
         name: "Sepolia"
     },
     {
-        id: "polygon_mumbai",
-        name: "Polygon Mumbai"
+        id: "polygon_amoy",
+        name: "Polygon Amoy"
     },
     {
         id: "optimism_sepolia",


### PR DESCRIPTION


## Description
polygon mumbai has been deprecated, and this change updates the network to polygon amoy.

## Related Issue

#534

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No



## Other information

![image](https://github.com/user-attachments/assets/616cb74d-5f11-4e1e-9461-e30a9ce96665)


