### PR TITLE
style: make group cards responsive and add text truncate property to …

### DIFF
--- a/apps/dashboard/src/components/group-card.tsx
+++ b/apps/dashboard/src/components/group-card.tsx
@@ -40,6 +40,7 @@ export default function GroupCard({
             fontFamily="DM Sans, sans-serif"
             p="24px"
             minW="330px"
+            maxW="370px"
             h="280px"
         >
             <Box>
@@ -84,6 +85,7 @@ export default function GroupCard({
 
                 <Text
                     mt="12px"
+                    noOfLines={2}
                     color={!description ? "balticSea.300" : "balticSea.600"}
                 >
                     {type !== "on-chain" &&

--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -350,7 +350,7 @@ ${memberIds.join("\n")}
                 </Heading>
 
                 {_group.description && (
-                    <Text mt="15px" color="balticSea.800">
+                    <Text mt="15px" color="balticSea.800" maxW="70vw">
                         {_group.description}
                     </Text>
                 )}


### PR DESCRIPTION

## Description

I made the group page cards responsive. If the description text is too long, it will now be truncated to display a maximum of two lines (noOfLines={2}), ensuring the layout remains clean and readable

## Related Issue
https://github.com/bandada-infra/bandada/issues/553

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No



## Other information

https://github.com/user-attachments/assets/95d35a4a-9d9d-4a5a-b534-271e64c42d29

