### PR TITLE
fix(api-sdk): fix get groups function

### DIFF
--- a/apps/api/src/app/groups/docSchemas/group.ts
+++ b/apps/api/src/app/groups/docSchemas/group.ts
@@ -20,5 +20,5 @@ export class Group {
     @ApiProperty({ isArray: true })
     members: string
     @ApiProperty()
-    credentials: object
+    credentials: string
 }

--- a/apps/api/src/app/groups/dto/create-group.dto.ts
+++ b/apps/api/src/app/groups/dto/create-group.dto.ts
@@ -43,6 +43,10 @@ export class CreateGroupDto {
 
     @IsJSON()
     @IsOptional()
-    @ApiProperty()
+    @ApiProperty({
+        default:
+            '{"id":"BLOCKCHAIN_BALANCE","criteria":{"minBalance":"10","network":"Sepolia"}}',
+        type: String
+    })
     readonly credentials?: any
 }

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -13,12 +13,22 @@ const url = "/groups"
  * @returns List of groups.
  */
 export async function getGroups(config: object): Promise<Group[]> {
-    const groups = await request(url, config)
+    let groups = await request(url, config)
 
-    groups.map((group: any) => ({
-        ...group,
-        credentials: JSON.parse(group.credentials)
-    }))
+    groups = groups.map((group: any) => {
+        let credentials
+
+        try {
+            credentials = JSON.parse(group.credentials)
+        } catch (error) {
+            credentials = null
+        }
+
+        return {
+            ...group,
+            credentials
+        }
+    })
 
     return groups
 }
@@ -34,12 +44,22 @@ export async function getGroupsByAdminId(
 ): Promise<Group[]> {
     const requestUrl = `${url}?adminId=${adminId}`
 
-    const groups = await request(requestUrl, config)
+    let groups = await request(requestUrl, config)
 
-    groups.map((group: any) => ({
-        ...group,
-        credentials: JSON.parse(group.credentials)
-    }))
+    groups = groups.map((group: any) => {
+        let credentials
+
+        try {
+            credentials = JSON.parse(group.credentials)
+        } catch (error) {
+            credentials = null
+        }
+
+        return {
+            ...group,
+            credentials
+        }
+    })
 
     return groups
 }
@@ -55,12 +75,22 @@ export async function getGroupsByMemberId(
 ): Promise<Group[]> {
     const requestUrl = `${url}?memberId=${memberId}`
 
-    const groups = await request(requestUrl, config)
+    let groups = await request(requestUrl, config)
 
-    groups.map((group: any) => ({
-        ...group,
-        credentials: JSON.parse(group.credentials)
-    }))
+    groups = groups.map((group: any) => {
+        let credentials
+
+        try {
+            credentials = JSON.parse(group.credentials)
+        } catch (error) {
+            credentials = null
+        }
+
+        return {
+            ...group,
+            credentials
+        }
+    })
 
     return groups
 }
@@ -76,9 +106,22 @@ export async function createGroups(
     groupsCreationDetails: Array<GroupCreationDetails>,
     apiKey: string
 ): Promise<Array<Group>> {
+    const groupsCreationDetailsRequest = groupsCreationDetails.map((group) => {
+        if (group.credentials) {
+            return {
+                ...group,
+                credentials: JSON.stringify(group.credentials)
+            }
+        }
+
+        return {
+            ...group
+        }
+    })
+
     const newConfig: any = {
         method: "post",
-        data: groupsCreationDetails,
+        data: groupsCreationDetailsRequest,
         ...config
     }
 
@@ -204,7 +247,15 @@ export async function getGroup(
 
     const group = await request(requestUrl, config)
 
-    group.credentials = JSON.parse(group.credentials)
+    let credentials
+
+    try {
+        credentials = JSON.parse(group.credentials)
+    } catch (error) {
+        credentials = null
+    }
+
+    group.credentials = credentials
 
     return group
 }

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -125,10 +125,124 @@ describe("Bandada API SDK", () => {
                 expect(group.name).toBe(expectedGroup.name)
                 expect(group.treeDepth).toBe(expectedGroup.treeDepth)
                 expect(group.fingerprintDuration).toBe(
-                    group.fingerprintDuration
+                    expectedGroup.fingerprintDuration
                 )
                 expect(group.members).toHaveLength(0)
                 expect(group.credentials).toBeNull()
+            })
+            it("Should create a credential group", async () => {
+                const credentials = {
+                    id: "BLOCKCHAIN_BALANCE",
+                    criteria: {
+                        minBalance: "10",
+                        network: "Sepolia"
+                    }
+                }
+
+                const expectedGroup: GroupCreationDetails = {
+                    name: "Group1",
+                    description: "This is a new group",
+                    treeDepth: 16,
+                    fingerprintDuration: 3600,
+                    credentials
+                }
+                const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: [],
+                            credentials: JSON.stringify(credentials)
+                        }
+                    ])
+                )
+
+                apiSdk = new ApiSdk(SupportedUrl.DEV)
+                const group: Group = await apiSdk.createGroup(
+                    expectedGroup,
+                    apiKey
+                )
+
+                expect(group.description).toBe(expectedGroup.description)
+                expect(group.name).toBe(expectedGroup.name)
+                expect(group.treeDepth).toBe(expectedGroup.treeDepth)
+                expect(group.fingerprintDuration).toBe(
+                    expectedGroup.fingerprintDuration
+                )
+                expect(group.members).toHaveLength(0)
+                expect(group.credentials).toStrictEqual(
+                    JSON.stringify(expectedGroup.credentials)
+                )
+            })
+            it("Should create a multiple credentials group", async () => {
+                const credentials = {
+                    credentials: [
+                        {
+                            id: "BLOCKCHAIN_TRANSACTIONS",
+                            criteria: {
+                                minTransactions: 10,
+                                network: "Sepolia"
+                            }
+                        },
+                        {
+                            id: "BLOCKCHAIN_BALANCE",
+                            criteria: {
+                                minBalance: "5",
+                                network: "Sepolia"
+                            }
+                        }
+                    ],
+                    expression: ["", "and", ""]
+                }
+
+                const expectedGroup: GroupCreationDetails = {
+                    name: "Group1",
+                    description: "This is a new group",
+                    treeDepth: 16,
+                    fingerprintDuration: 3600,
+                    credentials
+                }
+                const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: [],
+                            credentials: JSON.stringify(credentials)
+                        }
+                    ])
+                )
+
+                apiSdk = new ApiSdk(SupportedUrl.DEV)
+                const group: Group = await apiSdk.createGroup(
+                    expectedGroup,
+                    apiKey
+                )
+
+                expect(group.description).toBe(expectedGroup.description)
+                expect(group.name).toBe(expectedGroup.name)
+                expect(group.treeDepth).toBe(expectedGroup.treeDepth)
+                expect(group.fingerprintDuration).toBe(
+                    expectedGroup.fingerprintDuration
+                )
+                expect(group.members).toHaveLength(0)
+                expect(group.credentials).toStrictEqual(
+                    JSON.stringify(expectedGroup.credentials)
+                )
             })
         })
         describe("#createGroups", () => {
@@ -189,7 +303,7 @@ describe("Bandada API SDK", () => {
                     expect(group.name).toBe(expectedGroups[i].name)
                     expect(group.treeDepth).toBe(expectedGroups[i].treeDepth)
                     expect(group.fingerprintDuration).toBe(
-                        group.fingerprintDuration
+                        expectedGroups[i].fingerprintDuration
                     )
                     expect(group.members).toHaveLength(0)
                     expect(group.credentials).toBeNull()
@@ -345,6 +459,27 @@ describe("Bandada API SDK", () => {
                 const groups: Group[] = await apiSdk.getGroups()
                 expect(groups).toHaveLength(1)
             })
+            it("Should return all groups and null in the credentials that don't have a valid JSON string", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: [],
+                            credentials: {}
+                        }
+                    ])
+                )
+                apiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups: Group[] = await apiSdk.getGroups()
+                expect(groups).toHaveLength(1)
+                expect(groups[0].credentials).toBeNull()
+            })
         })
         describe("#getGroupsByAdminId", () => {
             it("Should return all groups by admin id", async () => {
@@ -374,6 +509,34 @@ describe("Bandada API SDK", () => {
                     expect(group.admin).toBe(adminId)
                 })
             })
+            it("Should return all groups by admin id and null in the credentials that don't have a valid JSON string", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: [],
+                            credentials: {}
+                        }
+                    ])
+                )
+
+                const adminId =
+                    "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847"
+
+                apiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups: Group[] = await apiSdk.getGroupsByAdminId(adminId)
+                expect(groups).toHaveLength(1)
+                groups.forEach((group: Group) => {
+                    expect(group.admin).toBe(adminId)
+                    expect(group.credentials).toBeNull()
+                })
+            })
         })
         describe("#getGroupsByMemberId", () => {
             it("Should return all groups by member id", async () => {
@@ -401,6 +564,32 @@ describe("Bandada API SDK", () => {
                 )
                 expect(groups).toHaveLength(1)
             })
+            it("Should return all groups by member id and null in the credentials that don't have a valid JSON string", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: ["1"],
+                            credentials: {}
+                        }
+                    ])
+                )
+
+                const memberId = "1"
+
+                apiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups: Group[] = await apiSdk.getGroupsByMemberId(
+                    memberId
+                )
+                expect(groups).toHaveLength(1)
+                expect(groups[0].credentials).toBeNull()
+            })
         })
         describe("#getGroup", () => {
             it("Should return a group", async () => {
@@ -422,6 +611,55 @@ describe("Bandada API SDK", () => {
                 apiSdk = new ApiSdk(SupportedUrl.DEV)
                 const group: Group = await apiSdk.getGroup(groupId)
                 expect(group.id).toBe(groupId)
+            })
+            it("Should return a credential group", async () => {
+                const credentials = {
+                    id: "BLOCKCHAIN_BALANCE",
+                    criteria: {
+                        minBalance: "10",
+                        network: "Sepolia"
+                    }
+                }
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve({
+                        id: "10402173435763029700781503965100",
+                        name: "Group1",
+                        description: "This is a new group",
+                        admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                        treeDepth: 16,
+                        fingerprintDuration: 3600,
+                        createdAt: "2023-07-15T08:21:05.000Z",
+                        members: [],
+                        credentials: JSON.stringify(credentials)
+                    })
+                )
+                const groupId = "10402173435763029700781503965100"
+
+                apiSdk = new ApiSdk(SupportedUrl.DEV)
+                const group: Group = await apiSdk.getGroup(groupId)
+                expect(group.id).toBe(groupId)
+                expect(group.credentials).toStrictEqual(credentials)
+            })
+            it("Should return null in credentials if credentials is not a valid JSON string", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve({
+                        id: "10402173435763029700781503965100",
+                        name: "Group1",
+                        description: "This is a new group",
+                        admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                        treeDepth: 16,
+                        fingerprintDuration: 3600,
+                        createdAt: "2023-07-15T08:21:05.000Z",
+                        members: [],
+                        credentials: {}
+                    })
+                )
+                const groupId = "10402173435763029700781503965100"
+
+                apiSdk = new ApiSdk(SupportedUrl.DEV)
+                const group: Group = await apiSdk.getGroup(groupId)
+                expect(group.id).toBe(groupId)
+                expect(group.credentials).toBeNull()
             })
         })
         describe("#isGroupMember", () => {

--- a/libs/api-sdk/src/types/index.ts
+++ b/libs/api-sdk/src/types/index.ts
@@ -1,7 +1,4 @@
-export type Credential = {
-    id: string
-    criteria: Record<string, any>
-}
+export type Credential = any
 
 export type Group = {
     id: string

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "start": "yarn workspaces foreach --exclude bandada-docs -A -pi run start",
         "dev": "yarn workspaces foreach --exclude contracts --exclude bandada-website -A -pi run dev",
         "test": "jest && yarn workspace contracts test",
+        "test:library": "jest libs/${0}",
         "test:coverage": "yarn test:jest:coverage && yarn test:contracts:coverage",
         "test:jest:coverage": "jest --coverage",
         "test:contracts:coverage": "yarn workspace contracts test:coverage",


### PR DESCRIPTION
## Description

This PR:

- Fixes the `getGroups()` function in the API SDK.
   - A try catch was added to add `null` to the credentials that are not a valid JSON string.
- Updates the group credentials type in the API docs from object to string.
- Updates the default value for a credential group from `{}` to `'{"id":"BLOCKCHAIN_BALANCE","criteria":{"minBalance":"10","network":"Sepolia"}}'`.
- Improves developer experience when creating a credential groups programmatically.
- Adds support for multiple credentials groups.
- Adds a new script to run tests for a specific library: `yarn test:library <package-name>`.

## Related Issue

Closes #561

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
