### PR TITLE
docs: add credential groups to readme and docs

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,8 +8,8 @@
         "build": "nest build"
     },
     "dependencies": {
-        "@bandada/credentials": "2.3.1",
-        "@bandada/utils": "2.3.1",
+        "@bandada/credentials": "2.3.2",
+        "@bandada/utils": "2.3.2",
         "@ethersproject/hash": "^5.7.0",
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -8,8 +8,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@bandada/api-sdk": "2.3.1",
-        "@bandada/utils": "2.3.1",
+        "@bandada/api-sdk": "2.3.2",
+        "@bandada/utils": "2.3.2",
         "@chakra-ui/react": "^2.5.1",
         "@chakra-ui/styled-system": "^2.0.0",
         "@chakra-ui/theme-tools": "^2.0.16",

--- a/apps/contracts/contracts/package.json
+++ b/apps/contracts/contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandada/contracts",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "Bandada smart contracts to manage off-chain groups and verify their zero-knowledge proofs.",
     "license": "MIT",
     "files": [

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -8,8 +8,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@bandada/credentials": "2.3.1",
-        "@bandada/utils": "2.3.1",
+        "@bandada/credentials": "2.3.2",
+        "@bandada/utils": "2.3.2",
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.5.1",
         "@chakra-ui/styled-system": "^2.0.0",

--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -110,6 +110,72 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const group = await apiSdk.createGroup(groupCreateDetails, apiKey)
 ```
 
+## Create a credential group
+
+\# **createGroup**(): _Promise\<Group>_
+
+Creates a Bandada credential group.
+
+```ts
+const credentials = {
+    id: "BLOCKCHAIN_BALANCE",
+    criteria: {
+        minBalance: "10",
+        network: "Sepolia"
+    }
+}
+
+const groupCreateDetails = {
+    name: "Group 1",
+    description: "This is Group 1.",
+    treeDepth: 16,
+    fingerprintDuration: 3600,
+    credentials
+}
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+const group = await apiSdk.createGroup(groupCreateDetails, apiKey)
+```
+
+## Create a multiple credentials group
+
+\# **createGroup**(): _Promise\<Group>_
+
+Creates a Bandada multiple credential group.
+
+```ts
+const credentials = {
+    credentials: [
+        {
+            id: "BLOCKCHAIN_TRANSACTIONS",
+            criteria: {
+                minTransactions: 10,
+                network: "Sepolia"
+            }
+        },
+        {
+            id: "BLOCKCHAIN_BALANCE",
+            criteria: {
+                minBalance: "5",
+                network: "Sepolia"
+            }
+        }
+    ],
+    expression: ["", "and", ""]
+}
+
+const groupCreateDetails = {
+    name: "Group 1",
+    description: "This is Group 1.",
+    treeDepth: 16,
+    fingerprintDuration: 3600,
+    credentials
+}
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+const group = await apiSdk.createGroup(groupCreateDetails, apiKey)
+```
+
 ## Create groups
 
 \# **createGroups**(): _Promise\<Group[]>_

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -133,6 +133,72 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const group = await apiSdk.createGroup(groupCreateDetails, apiKey)
 ```
 
+## Create a credential group
+
+\# **createGroup**(): _Promise\<Group>_
+
+Creates a Bandada credential group.
+
+```ts
+const credentials = {
+    id: "BLOCKCHAIN_BALANCE",
+    criteria: {
+        minBalance: "10",
+        network: "Sepolia"
+    }
+}
+
+const groupCreateDetails = {
+    name: "Group 1",
+    description: "This is Group 1.",
+    treeDepth: 16,
+    fingerprintDuration: 3600,
+    credentials
+}
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+const group = await apiSdk.createGroup(groupCreateDetails, apiKey)
+```
+
+## Create a multiple credentials group
+
+\# **createGroup**(): _Promise\<Group>_
+
+Creates a Bandada multiple credential group.
+
+```ts
+const credentials = {
+    credentials: [
+        {
+            id: "BLOCKCHAIN_TRANSACTIONS",
+            criteria: {
+                minTransactions: 10,
+                network: "Sepolia"
+            }
+        },
+        {
+            id: "BLOCKCHAIN_BALANCE",
+            criteria: {
+                minBalance: "5",
+                network: "Sepolia"
+            }
+        }
+    ],
+    expression: ["", "and", ""]
+}
+
+const groupCreateDetails = {
+    name: "Group 1",
+    description: "This is Group 1.",
+    treeDepth: 16,
+    fingerprintDuration: 3600,
+    credentials
+}
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+const group = await apiSdk.createGroup(groupCreateDetails, apiKey)
+```
+
 ## Create groups
 
 \# **createGroups**(): _Promise\<Group[]>_

--- a/libs/api-sdk/package.json
+++ b/libs/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandada/api-sdk",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "A Typescript SDK for the Bandada API.",
     "license": "MIT",
     "main": "dist/index.node.js",
@@ -30,7 +30,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@bandada/utils": "2.3.1"
+        "@bandada/utils": "2.3.2"
     },
     "devDependencies": {
         "@rollup/plugin-typescript": "^11.0.0",

--- a/libs/credentials/package.json
+++ b/libs/credentials/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandada/credentials",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "Bandada library to validate users' credentials.",
     "license": "MIT",
     "main": "dist/index.node.js",
@@ -30,7 +30,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@bandada/utils": "2.3.1",
+        "@bandada/utils": "2.3.2",
         "@zk-kit/logical-expressions": "1.0.0",
         "ethers": "5.7.0"
     },

--- a/libs/hardhat/package.json
+++ b/libs/hardhat/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandada/hardhat",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "A Hardhat plugin which provides tasks to deploy Bandada contracts.",
     "license": "MIT",
     "main": "dist/index.node.js",
@@ -40,7 +40,7 @@
         "typescript": "^4.9.5"
     },
     "peerDependencies": {
-        "@bandada/contracts": "2.3.1",
+        "@bandada/contracts": "2.3.2",
         "@nomiclabs/hardhat-ethers": "^2.0.0",
         "@semaphore-protocol/contracts": "3.4.0",
         "ethers": "^5.4.7",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandada/utils",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "General Bandada utility functions.",
     "license": "MIT",
     "main": "dist/index.node.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,11 +2317,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bandada/api-sdk@npm:2.3.1, @bandada/api-sdk@workspace:libs/api-sdk":
+"@bandada/api-sdk@npm:2.3.2, @bandada/api-sdk@workspace:libs/api-sdk":
   version: 0.0.0-use.local
   resolution: "@bandada/api-sdk@workspace:libs/api-sdk"
   dependencies:
-    "@bandada/utils": "npm:2.3.1"
+    "@bandada/utils": "npm:2.3.2"
     "@rollup/plugin-typescript": "npm:^11.0.0"
     rimraf: "npm:^4.1.2"
     rollup: "npm:^3.17.2"
@@ -2339,11 +2339,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bandada/credentials@npm:2.3.1, @bandada/credentials@workspace:libs/credentials":
+"@bandada/credentials@npm:2.3.2, @bandada/credentials@workspace:libs/credentials":
   version: 0.0.0-use.local
   resolution: "@bandada/credentials@workspace:libs/credentials"
   dependencies:
-    "@bandada/utils": "npm:2.3.1"
+    "@bandada/utils": "npm:2.3.2"
     "@rollup/plugin-typescript": "npm:^11.0.0"
     "@zk-kit/logical-expressions": "npm:1.0.0"
     ethers: "npm:5.7.0"
@@ -2368,7 +2368,7 @@ __metadata:
     rollup-plugin-cleanup: "npm:^3.2.1"
     typescript: "npm:^4.9.5"
   peerDependencies:
-    "@bandada/contracts": 2.3.1
+    "@bandada/contracts": 2.3.2
     "@nomiclabs/hardhat-ethers": ^2.0.0
     "@semaphore-protocol/contracts": 3.4.0
     ethers: ^5.4.7
@@ -2376,7 +2376,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bandada/utils@npm:2.3.1, @bandada/utils@workspace:libs/utils":
+"@bandada/utils@npm:2.3.2, @bandada/utils@workspace:libs/utils":
   version: 0.0.0-use.local
   resolution: "@bandada/utils@workspace:libs/utils"
   dependencies:
@@ -10950,8 +10950,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "api@workspace:apps/api"
   dependencies:
-    "@bandada/credentials": "npm:2.3.1"
-    "@bandada/utils": "npm:2.3.1"
+    "@bandada/credentials": "npm:2.3.2"
+    "@bandada/utils": "npm:2.3.2"
     "@ethersproject/hash": "npm:^5.7.0"
     "@nestjs/cli": "npm:^9.0.0"
     "@nestjs/common": "npm:^9.0.0"
@@ -13022,8 +13022,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "client@workspace:apps/client"
   dependencies:
-    "@bandada/api-sdk": "npm:2.3.1"
-    "@bandada/utils": "npm:2.3.1"
+    "@bandada/api-sdk": "npm:2.3.2"
+    "@bandada/utils": "npm:2.3.2"
     "@chakra-ui/react": "npm:^2.5.1"
     "@chakra-ui/styled-system": "npm:^2.0.0"
     "@chakra-ui/theme-tools": "npm:^2.0.16"
@@ -14249,8 +14249,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "dashboard@workspace:apps/dashboard"
   dependencies:
-    "@bandada/credentials": "npm:2.3.1"
-    "@bandada/utils": "npm:2.3.1"
+    "@bandada/credentials": "npm:2.3.2"
+    "@bandada/utils": "npm:2.3.2"
     "@chakra-ui/icons": "npm:^2.1.1"
     "@chakra-ui/react": "npm:^2.5.1"
     "@chakra-ui/styled-system": "npm:^2.0.0"


### PR DESCRIPTION
## Description

This PR adds code examples to create credential and multiple credentials groups to the `api-sdk` Readme file and the docs.

## Related Issue

Closes #563

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

