### PR TITLE
Improve and fix libs-credentials

### DIFF
--- a/libs/credentials/README.md
+++ b/libs/credentials/README.md
@@ -70,13 +70,8 @@ yarn add @bandada/credentials
 \# **validateCredentials**(credentials: _Credentials_, context: _Context_)
 
 ```typescript
-import {
-    validateCredentials,
-    githubFollowers,
-    EASNetworks
-} from "@bandada/credentials"
+import { validateCredentials, githubFollowers } from "@bandada/credentials"
 
-// Validate Web2 credentials
 validateCredentials(
     {
         id: githubFollowers.id,
@@ -88,42 +83,6 @@ validateCredentials(
         accessToken: {
             github: "token"
         }
-    }
-)
-
-// Validate blockchain credentials
-validateCredentials(
-    {
-        id: blockchainBalance.id,
-        criteria: {
-            minBalance: "10",
-            network: "sepolia",
-            blockNumber: 4749638
-        }
-    },
-    {
-        address: "0x",
-        jsonRpcProvider
-    }
-)
-
-// Validate EAS attestations credentials
-validateCredentials(
-    {
-        id: easAttestations.id,
-        criteria: {
-            minAttestations: 1,
-            recipient: "0x0",
-            attester: "0x1",
-            schemaId: "0x2",
-            revocable: true,
-            revoked: false,
-            isOffchain: false
-        }
-    },
-    {
-        network: EASNetworks.ETHEREUM,
-        address: "0x1"
     }
 )
 ```

--- a/libs/credentials/README.md
+++ b/libs/credentials/README.md
@@ -70,8 +70,13 @@ yarn add @bandada/credentials
 \# **validateCredentials**(credentials: _Credentials_, context: _Context_)
 
 ```typescript
-import { validateCredentials, githubFollowers } from "@bandada/credentials"
+import {
+    validateCredentials,
+    githubFollowers,
+    EASNetworks
+} from "@bandada/credentials"
 
+// Validate Web2 credentials
 validateCredentials(
     {
         id: githubFollowers.id,
@@ -83,6 +88,42 @@ validateCredentials(
         accessToken: {
             github: "token"
         }
+    }
+)
+
+// Validate blockchain credentials
+validateCredentials(
+    {
+        id: blockchainBalance.id,
+        criteria: {
+            minBalance: "10",
+            network: "sepolia",
+            blockNumber: 4749638
+        }
+    },
+    {
+        address: "0x",
+        jsonRpcProvider
+    }
+)
+
+// Validate EAS attestations credentials
+validateCredentials(
+    {
+        id: easAttestations.id,
+        criteria: {
+            minAttestations: 1,
+            recipient: "0x0",
+            attester: "0x1",
+            schemaId: "0x2",
+            revocable: true,
+            revoked: false,
+            isOffchain: false
+        }
+    },
+    {
+        network: EASNetworks.ETHEREUM,
+        address: "0x1"
     }
 )
 ```

--- a/libs/credentials/src/index.test.ts
+++ b/libs/credentials/src/index.test.ts
@@ -147,12 +147,16 @@ describe("Credentials library", () => {
     })
 
     describe("# queryGraph", () => {
-        it("Should return a function that can be used to query graphs data using GraphQL", () => {
-            const query = queryGraph(
+        it("Should return a function that can be used to query graphs data using GraphQL", async () => {
+            const query = await queryGraph(
                 "https://easscan.org/graphql",
                 `
                 query {
-                    attestations {
+                    attestations(where: {
+                        recipient: {
+                            equals: "0x"
+                        }
+                    }) {
                         recipient
                         attester
                         revocable
@@ -164,7 +168,7 @@ describe("Credentials library", () => {
             `
             )
 
-            expect(query).toBeUndefined()
+            expect(query).toEqual({})
         })
     })
 

--- a/libs/credentials/src/queryGraph.ts
+++ b/libs/credentials/src/queryGraph.ts
@@ -8,7 +8,7 @@ import { request } from "@bandada/utils"
  * @returns The function to query the graph.
  */
 export default function queryGraph(endpoint: string, query: string) {
-    request(endpoint, {
+    return request(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         data: JSON.stringify({

--- a/libs/credentials/src/types/index.ts
+++ b/libs/credentials/src/types/index.ts
@@ -27,7 +27,8 @@ export type BlockchainContext = {
 }
 
 export type EASContext = {
-    queryGraph: (query: string) => Promise<any>
+    network: EASNetworks
+    address: BigNumberish
 }
 
 export type Context = Web2Context | BlockchainContext | EASContext

--- a/libs/credentials/src/validators/easAttestations/index.test.ts
+++ b/libs/credentials/src/validators/easAttestations/index.test.ts
@@ -36,7 +36,6 @@ describe("EASAttestations", () => {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -62,7 +61,6 @@ describe("EASAttestations", () => {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d4",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -88,7 +86,6 @@ describe("EASAttestations", () => {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5d",
@@ -114,7 +111,6 @@ describe("EASAttestations", () => {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -140,7 +136,6 @@ describe("EASAttestations", () => {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -166,7 +161,6 @@ describe("EASAttestations", () => {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",

--- a/libs/credentials/src/validators/easAttestations/index.test.ts
+++ b/libs/credentials/src/validators/easAttestations/index.test.ts
@@ -1,65 +1,26 @@
-import { validateCredentials } from "../.."
+import { EASNetworks, validateCredentials } from "../.."
 import easAttestations from "./index"
 
+jest.mock("../..", () => ({
+    EASNetworks: { ETHEREUM_SEPOLIA: "sepolia" },
+    validateCredentials: jest.fn(() => true)
+}))
+
 describe("EASAttestations", () => {
-    const queryGraphMocked = {
-        queryGraph: jest.fn()
-    }
-
-    queryGraphMocked.queryGraph.mockReturnValue([
-        {
-            id: "0x52561c95029d9f2335839ddc96a69ee9737a18e2a781e64659b7bd645ccb8efc",
-            recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
-            attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
-            revocable: true,
-            revoked: false,
-            schemaId:
-                "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
-            isOffchain: false
-        },
-        {
-            id: "0xee06a022c7d55f67bac213d6b2cd384a899ef79a57f1f5f148e45c313b4fdebe",
-            recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
-            attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
-            revocable: true,
-            revoked: false,
-            schemaId:
-                "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
-            isOffchain: false
-        },
-        {
-            id: "0xfbc0f1aac4379c18fa9a5b6493825234a8ca82a2a296148465d150c2e64c6202",
-            recipient: "0x0000000000000000000000000000000000000000",
-            attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
-            revocable: true,
-            revoked: false,
-            schemaId:
-                "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
-            isOffchain: false
-        },
-        {
-            id: "0x227510204bcfe7b543388b82c6e02aafe7b0d0a20e4f159794e8121611aa601b",
-            recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
-            attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
-            revocable: true,
-            revoked: false,
-            schemaId:
-                "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
-            isOffchain: false
-        }
-    ])
-
     it("Should return true if an account has greater than or equal to 3 attestations", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => true)
+
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 3,
-                    recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8"
+                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d"
                 }
             },
             {
-                queryGraph: queryGraphMocked.queryGraph
+                network: EASNetworks.ETHEREUM_SEPOLIA,
+                address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3"
             }
         )
 
@@ -67,12 +28,14 @@ describe("EASAttestations", () => {
     })
 
     it("Should return true if the given optional criterias are satisfied", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => true)
+
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -82,7 +45,8 @@ describe("EASAttestations", () => {
                 }
             },
             {
-                queryGraph: queryGraphMocked.queryGraph
+                network: EASNetworks.ETHEREUM_SEPOLIA,
+                address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3"
             }
         )
 
@@ -90,12 +54,14 @@ describe("EASAttestations", () => {
     })
 
     it("Should return false if the attester optional criteria doesn't match", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => false)
+
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d4",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -105,7 +71,8 @@ describe("EASAttestations", () => {
                 }
             },
             {
-                queryGraph: queryGraphMocked.queryGraph
+                network: EASNetworks.ETHEREUM_SEPOLIA,
+                address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d4"
             }
         )
 
@@ -113,12 +80,14 @@ describe("EASAttestations", () => {
     })
 
     it("Should return false if the schemaId optional criteria doesn't match", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => false)
+
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5d",
@@ -128,7 +97,8 @@ describe("EASAttestations", () => {
                 }
             },
             {
-                queryGraph: queryGraphMocked.queryGraph
+                network: EASNetworks.ETHEREUM_SEPOLIA,
+                address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3"
             }
         )
 
@@ -136,12 +106,14 @@ describe("EASAttestations", () => {
     })
 
     it("Should return false if the revocable optional criteria doesn't match", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => false)
+
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -151,7 +123,8 @@ describe("EASAttestations", () => {
                 }
             },
             {
-                queryGraph: queryGraphMocked.queryGraph
+                network: EASNetworks.ETHEREUM_SEPOLIA,
+                address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3"
             }
         )
 
@@ -159,12 +132,14 @@ describe("EASAttestations", () => {
     })
 
     it("Should return false if the revoked optional criteria doesn't match", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => false)
+
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -174,7 +149,8 @@ describe("EASAttestations", () => {
                 }
             },
             {
-                queryGraph: queryGraphMocked.queryGraph
+                network: EASNetworks.ETHEREUM_SEPOLIA,
+                address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3"
             }
         )
 
@@ -182,12 +158,14 @@ describe("EASAttestations", () => {
     })
 
     it("Should return false if the isOffchain optional criteria doesn't match", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => false)
+
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae8",
+                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -197,7 +175,8 @@ describe("EASAttestations", () => {
                 }
             },
             {
-                queryGraph: queryGraphMocked.queryGraph
+                network: EASNetworks.ETHEREUM_SEPOLIA,
+                address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3"
             }
         )
 
@@ -205,16 +184,19 @@ describe("EASAttestations", () => {
     })
 
     it("Should return false if an account has less than 3 attestations", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => false)
+
         const result = await validateCredentials(
             {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 3,
-                    recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae9"
+                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d"
                 }
             },
             {
-                queryGraph: queryGraphMocked.queryGraph
+                network: EASNetworks.ETHEREUM_SEPOLIA,
+                address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d4"
             }
         )
 
@@ -222,6 +204,10 @@ describe("EASAttestations", () => {
     })
 
     it("Should throw an error if a mandatory criteria parameter is missing", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => {
+            throw new Error("Parameter 'minAttestations' has not been defined")
+        })
+
         const fun = () =>
             validateCredentials(
                 {
@@ -229,7 +215,8 @@ describe("EASAttestations", () => {
                     criteria: {}
                 },
                 {
-                    queryGraph: queryGraphMocked.queryGraph
+                    network: EASNetworks.ETHEREUM_SEPOLIA,
+                    address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3"
                 }
             )
 
@@ -239,18 +226,25 @@ describe("EASAttestations", () => {
     })
 
     it("Should throw an error if a criteria parameter should not exist", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => {
+            throw new Error(
+                "Parameter 'test' should not be part of the criteria"
+            )
+        })
+
         const fun = () =>
             validateCredentials(
                 {
                     id: easAttestations.id,
                     criteria: {
                         minAttestations: 1,
-                        recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae9",
+                        recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
                         test: 123
                     }
                 },
                 {
-                    queryGraph: queryGraphMocked.queryGraph
+                    network: EASNetworks.ETHEREUM_SEPOLIA,
+                    address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3"
                 }
             )
 
@@ -260,17 +254,22 @@ describe("EASAttestations", () => {
     })
 
     it("Should throw a type error if a criteria parameter has the wrong type", async () => {
+        ;(validateCredentials as any).mockImplementationOnce(async () => {
+            throw new Error("Parameter 'minAttestations' is not a number")
+        })
+
         const fun = () =>
             validateCredentials(
                 {
                     id: easAttestations.id,
                     criteria: {
                         minAttestations: "1",
-                        recipient: "0x9aB3971e1b065701C72C5f3cAFbF33118dC51ae9"
+                        recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d"
                     }
                 },
                 {
-                    queryGraph: queryGraphMocked.queryGraph
+                    network: EASNetworks.ETHEREUM_SEPOLIA,
+                    address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3"
                 }
             )
 

--- a/libs/credentials/src/validators/easAttestations/index.test.ts
+++ b/libs/credentials/src/validators/easAttestations/index.test.ts
@@ -15,7 +15,8 @@ describe("EASAttestations", () => {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 3,
-                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d"
+                    schemaId:
+                        "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c"
                 }
             },
             {
@@ -35,7 +36,7 @@ describe("EASAttestations", () => {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 1,
-                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
+                    recipient: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     attester: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d3",
                     schemaId:
                         "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
@@ -191,12 +192,13 @@ describe("EASAttestations", () => {
                 id: easAttestations.id,
                 criteria: {
                     minAttestations: 3,
-                    recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d"
+                    schemaId:
+                        "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c"
                 }
             },
             {
                 network: EASNetworks.ETHEREUM_SEPOLIA,
-                address: "0x63A35A52c0ac206108EBbf559E4C7109dAd281d4"
+                address: "0x"
             }
         )
 
@@ -238,7 +240,8 @@ describe("EASAttestations", () => {
                     id: easAttestations.id,
                     criteria: {
                         minAttestations: 1,
-                        recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d",
+                        schemaId:
+                            "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c",
                         test: 123
                     }
                 },
@@ -264,7 +267,8 @@ describe("EASAttestations", () => {
                     id: easAttestations.id,
                     criteria: {
                         minAttestations: "1",
-                        recipient: "0xBB00B71E34Df590847060A4c597821Bad585ED6d"
+                        schemaId:
+                            "0xe2636f31239f7948afdd9a9c477048b7fc2a089c347af60e3aa1251e5bf63e5c"
                     }
                 },
                 {

--- a/libs/credentials/src/validators/easAttestations/index.test.ts
+++ b/libs/credentials/src/validators/easAttestations/index.test.ts
@@ -3,7 +3,7 @@ import easAttestations from "./index"
 
 jest.mock("../..", () => ({
     EASNetworks: { ETHEREUM_SEPOLIA: "sepolia" },
-    validateCredentials: jest.fn(() => true)
+    validateCredentials: jest.fn()
 }))
 
 describe("EASAttestations", () => {

--- a/libs/credentials/src/validators/easAttestations/index.ts
+++ b/libs/credentials/src/validators/easAttestations/index.ts
@@ -3,9 +3,9 @@ import provider from "../../providers/eas"
 
 export type Criteria = {
     minAttestations: number
-    recipient: string
+    schemaId: string
     attester?: string
-    schemaId?: string
+    recipient?: string
     revocable?: boolean
     revoked?: boolean
     isOffchain?: boolean
@@ -19,7 +19,7 @@ const validator: Validator = {
             type: "number",
             optional: false
         },
-        recipient: {
+        schemaId: {
             type: "string",
             optional: false
         },
@@ -27,7 +27,7 @@ const validator: Validator = {
             type: "string",
             optional: true
         },
-        schemaId: {
+        recipient: {
             type: "string",
             optional: true
         },
@@ -64,10 +64,10 @@ const validator: Validator = {
 
             const query = `query {
                 attestations(where: {
-                    recipient: {
-                        equals: "${criteria.recipient}"
+                    schemaId: {
+                        equals: "${criteria.schemaId}"
                     },
-                    attester: {
+                    recipient: {
                         equals: "${context.address}"
                     }
                 }) {
@@ -88,16 +88,16 @@ const validator: Validator = {
             const filteredAttestations =
                 getAttestations.data.attestations.filter((attestation: any) => {
                     // Criteria checks.
-                    if (attestation.recipient !== recipient) return false
+                    if (attestation.schemaId !== schemaId) return false
+                    if (
+                        recipient !== undefined &&
+                        attestation.recipient !== recipient
+                    )
+                        return false
 
                     if (
                         attester !== undefined &&
                         attestation.attester !== attester
-                    )
-                        return false
-                    if (
-                        schemaId !== undefined &&
-                        attestation.schemaId !== schemaId
                     )
                         return false
                     if (

--- a/libs/credentials/src/validators/easAttestations/index.ts
+++ b/libs/credentials/src/validators/easAttestations/index.ts
@@ -3,9 +3,8 @@ import provider from "../../providers/eas"
 
 export type Criteria = {
     minAttestations: number
-    schemaId: string
+    schemaId?: string
     attester?: string
-    recipient?: string
     revocable?: boolean
     revoked?: boolean
     isOffchain?: boolean
@@ -18,10 +17,6 @@ const validator: Validator = {
         minAttestations: {
             type: "number",
             optional: false
-        },
-        recipient: {
-            type: "string",
-            optional: true
         },
         attester: {
             type: "string",

--- a/libs/credentials/src/validators/easAttestations/index.ts
+++ b/libs/credentials/src/validators/easAttestations/index.ts
@@ -57,37 +57,30 @@ const validator: Validator = {
                 isOffchain
             } = criteria
 
+            let whereConditions = `recipient: { equals: "${context.address}" }`
+
+            if (attester !== undefined && attester !== null) {
+                whereConditions += `attester: { equals: "${attester}" },`
+            }
+
+            if (schemaId !== undefined && schemaId !== null) {
+                whereConditions += `schemaId: { equals: "${schemaId}" },`
+            }
+
+            if (revocable !== undefined && revocable !== null) {
+                whereConditions += `revocable: { equals: ${revocable} },`
+            }
+
+            if (revoked !== undefined && revoked !== null) {
+                whereConditions += `revoked: { equals: ${revoked} },`
+            }
+
+            if (isOffchain !== undefined && isOffchain !== null) {
+                whereConditions += `isOffchain: { equals: ${isOffchain} },`
+            }
+
             const query = `query {
-                attestations(where: {                
-                    recipient: {
-                        equals: "${context.address}"
-                    },
-                    ${
-                        attester !== undefined && attester !== null
-                            ? `attester: { equals: "${attester}" },`
-                            : ""
-                    }
-                    ${
-                        schemaId !== undefined && schemaId !== null
-                            ? `schemaId: { equals: "${schemaId}" },`
-                            : ""
-                    }
-                    ${
-                        revocable !== undefined && revocable !== null
-                            ? `revocable: { equals: ${revocable} },`
-                            : ""
-                    }
-                    ${
-                        revoked !== undefined && revoked !== null
-                            ? `revoked: { equals: ${revoked} },`
-                            : ""
-                    }
-                    ${
-                        isOffchain !== undefined && isOffchain !== null
-                            ? `isOffchain: { equals: ${isOffchain} },`
-                            : ""
-                    }
-                }) {
+                attestations(where: { ${whereConditions} }) {
                     recipient
                     attester
                     schemaId


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes a bug where the `queryGraph` function does not return the `request` function as intended.

This PR also has a code refactor that introduces a breaking change at validate `easAttestation`.
Specifically, validate `easAttestation` context no longer takes in `queryGraph` but `network` and `address` instead.

Example (Old):
```ts
validateCredentials(
   {
     ...criteria
   },
   {
     queryGraph: () => queryGraph
   }
)
```

Example (New):
```ts
validateCredentials(
   {
     ...criteria
   },
   {
     network: EASNetworks.ETHEREUM,
     address: "0x"
   }
)
```

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#568

## Does this introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Please refer to the examples given above to migrate from the old easAttestation context to the new easAttestation context.
