### PR TITLE
Add EAS Attestation credentials to API and Dashboard

### DIFF
--- a/apps/api/src/app/credentials/credentials.service.ts
+++ b/apps/api/src/app/credentials/credentials.service.ts
@@ -7,8 +7,7 @@ import {
     providers,
     Web2Context,
     BlockchainContext,
-    EASContext,
-    EASNetworks
+    EASContext
 } from "@bandada/credentials"
 import { blockchainCredentialSupportedNetworks } from "@bandada/utils"
 import { id } from "@ethersproject/hash"
@@ -177,7 +176,6 @@ export class CredentialsService {
                     accountHash = id(address + groupId)
                 } else if (address && credentialProvider === "eas") {
                     context = {
-                        network: EASNetworks.ETHEREUM_SEPOLIA,
                         address: address[0]
                     }
 
@@ -276,7 +274,7 @@ export class CredentialsService {
                 group.credentials
             ).criteria
 
-            if (network) {
+            if (network && !minAttestations) {
                 const supportedNetwork =
                     blockchainCredentialSupportedNetworks.find(
                         (n) => n.name.toLowerCase() === network.toLowerCase()
@@ -302,9 +300,8 @@ export class CredentialsService {
                 }
             }
 
-            if (minAttestations) {
+            if (network && minAttestations) {
                 context = {
-                    network: EASNetworks.ETHEREUM_SEPOLIA,
                     address: address[0]
                 }
             }

--- a/apps/api/src/app/credentials/credentials.service.ts
+++ b/apps/api/src/app/credentials/credentials.service.ts
@@ -6,7 +6,9 @@ import {
     Web2Provider,
     providers,
     Web2Context,
-    BlockchainContext
+    BlockchainContext,
+    EASContext,
+    EASNetworks
 } from "@bandada/credentials"
 import { blockchainCredentialSupportedNetworks } from "@bandada/utils"
 import { id } from "@ethersproject/hash"
@@ -139,7 +141,7 @@ export class CredentialsService {
                 } = this.oAuthState.get(credentialOAuthState))
                 const provider = getProvider(providerName)
 
-                let context: Web2Context | BlockchainContext
+                let context: Web2Context | BlockchainContext | EASContext
 
                 if (address && credentialProvider === "blockchain") {
                     const { network } = credentials.credentials[i].criteria
@@ -169,6 +171,14 @@ export class CredentialsService {
                     context = {
                         address: address[0],
                         jsonRpcProvider
+                    }
+
+                    // Check if the same account has already joined the group.
+                    accountHash = id(address + groupId)
+                } else if (address && credentialProvider === "eas") {
+                    context = {
+                        network: EASNetworks.ETHEREUM_SEPOLIA,
+                        address: address[0]
                     }
 
                     // Check if the same account has already joined the group.
@@ -259,30 +269,44 @@ export class CredentialsService {
 
         let accountHash: string
 
-        let context: Web2Context | BlockchainContext
+        let context: Web2Context | BlockchainContext | EASContext
 
         if (address) {
-            const { network } = JSON.parse(group.credentials).criteria
+            const { network, minAttestations } = JSON.parse(
+                group.credentials
+            ).criteria
 
-            const supportedNetwork = blockchainCredentialSupportedNetworks.find(
-                (n) => n.name.toLowerCase() === network.toLowerCase()
-            )
+            if (network) {
+                const supportedNetwork =
+                    blockchainCredentialSupportedNetworks.find(
+                        (n) => n.name.toLowerCase() === network.toLowerCase()
+                    )
 
-            if (supportedNetwork === undefined)
-                throw new BadRequestException(`The network is not supported`)
+                if (supportedNetwork === undefined)
+                    throw new BadRequestException(
+                        `The network is not supported`
+                    )
 
-            const networkEnvVariableName = supportedNetwork.id.toUpperCase()
+                const networkEnvVariableName = supportedNetwork.id.toUpperCase()
 
-            const web3providerRpcURL =
-                process.env[`${networkEnvVariableName}_RPC_URL`]
+                const web3providerRpcURL =
+                    process.env[`${networkEnvVariableName}_RPC_URL`]
 
-            const jsonRpcProvider = await (
-                provider as BlockchainProvider
-            ).getJsonRpcProvider(web3providerRpcURL)
+                const jsonRpcProvider = await (
+                    provider as BlockchainProvider
+                ).getJsonRpcProvider(web3providerRpcURL)
 
-            context = {
-                address: address[0],
-                jsonRpcProvider
+                context = {
+                    address: address[0],
+                    jsonRpcProvider
+                }
+            }
+
+            if (minAttestations) {
+                context = {
+                    network: EASNetworks.ETHEREUM_SEPOLIA,
+                    address: address[0]
+                }
             }
 
             // Check if the same account has already joined the group.

--- a/apps/api/src/app/credentials/credentials.service.ts
+++ b/apps/api/src/app/credentials/credentials.service.ts
@@ -270,11 +270,10 @@ export class CredentialsService {
         let context: Web2Context | BlockchainContext | EASContext
 
         if (address) {
-            const { network, minAttestations } = JSON.parse(
-                group.credentials
-            ).criteria
+            const { network, minBalance, minTransactions, minAttestations } =
+                JSON.parse(group.credentials).criteria
 
-            if (network && !minAttestations) {
+            if (network && (minBalance || minTransactions)) {
                 const supportedNetwork =
                     blockchainCredentialSupportedNetworks.find(
                         (n) => n.name.toLowerCase() === network.toLowerCase()

--- a/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
+++ b/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
@@ -1,5 +1,5 @@
 import { validators } from "@bandada/credentials"
-import { blockchainCredentialSupportedNetworks } from "@bandada/utils"
+import { blockchainCredentialSupportedNetworks, easCredentialSupportedNetworks } from "@bandada/utils"
 import {
     Box,
     Button,
@@ -254,7 +254,15 @@ export default function AccessModeStep({
                                                     })
                                                 }
                                             >
-                                                {blockchainCredentialSupportedNetworks.map(
+                                                {validators[_validator].criteriaABI.minAttestations ? easCredentialSupportedNetworks.map(
+                                                    (network: any) => (
+                                                        <option
+                                                            value={network.id}
+                                                        >
+                                                            {network.name}
+                                                        </option>
+                                                    )
+                                                ) : blockchainCredentialSupportedNetworks.map(
                                                     (network: any) => (
                                                         <option
                                                             value={network.name}

--- a/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
+++ b/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
@@ -1,5 +1,8 @@
 import { validators } from "@bandada/credentials"
-import { blockchainCredentialSupportedNetworks, easCredentialSupportedNetworks } from "@bandada/utils"
+import {
+    blockchainCredentialSupportedNetworks,
+    easCredentialSupportedNetworks
+} from "@bandada/utils"
 import {
     Box,
     Button,
@@ -254,23 +257,30 @@ export default function AccessModeStep({
                                                     })
                                                 }
                                             >
-                                                {validators[_validator].criteriaABI.minAttestations ? easCredentialSupportedNetworks.map(
-                                                    (network: any) => (
-                                                        <option
-                                                            value={network.id}
-                                                        >
-                                                            {network.name}
-                                                        </option>
-                                                    )
-                                                ) : blockchainCredentialSupportedNetworks.map(
-                                                    (network: any) => (
-                                                        <option
-                                                            value={network.name}
-                                                        >
-                                                            {network.name}
-                                                        </option>
-                                                    )
-                                                )}
+                                                {validators[_validator]
+                                                    .criteriaABI.minAttestations
+                                                    ? easCredentialSupportedNetworks.map(
+                                                          (network: any) => (
+                                                              <option
+                                                                  value={
+                                                                      network.id
+                                                                  }
+                                                              >
+                                                                  {network.name}
+                                                              </option>
+                                                          )
+                                                      )
+                                                    : blockchainCredentialSupportedNetworks.map(
+                                                          (network: any) => (
+                                                              <option
+                                                                  value={
+                                                                      network.name
+                                                                  }
+                                                              >
+                                                                  {network.name}
+                                                              </option>
+                                                          )
+                                                      )}
                                             </Select>
                                         )}
                                     {parameter[1].type === "boolean" && (

--- a/apps/dashboard/src/pages/credentials.tsx
+++ b/apps/dashboard/src/pages/credentials.tsx
@@ -3,7 +3,8 @@ import {
     blockchain,
     Web2Provider,
     twitter,
-    github
+    github,
+    eas
 } from "@bandada/credentials"
 import { Flex, Text, Button } from "@chakra-ui/react"
 import { useEffect, useState, useCallback, useContext } from "react"
@@ -175,9 +176,10 @@ export default function CredentialsPage() {
                     clientRedirectUri
                 )
 
-                // If the credential is blockchain
+                // If the credential is blockchain or eas attestations
                 if (
-                    providerName === blockchain.name &&
+                    (providerName === blockchain.name ||
+                        providerName === eas.name) &&
                     isLoggedInAdmin() &&
                     state
                 ) {

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -8,7 +8,10 @@ import getWallet from "./getWallet"
 import getBandadaContract, { BandadaContract } from "./getBandadaContract"
 import request from "./request"
 import shortenAddress from "./shortenAddress"
-import { blockchainCredentialSupportedNetworks } from "./getSupportedNetworks"
+import {
+    blockchainCredentialSupportedNetworks,
+    easCredentialSupportedNetworks
+} from "./getSupportedNetworks"
 
 export {
     ApiKeyActions,
@@ -30,5 +33,6 @@ export {
     getContractAddresses,
     SemaphoreABI,
     BandadaABI,
-    blockchainCredentialSupportedNetworks
+    blockchainCredentialSupportedNetworks,
+    easCredentialSupportedNetworks
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR implements a new feature to the the credentials API for easAttestations, introduced by PR #569.
This PR also implements the said API for Dashboard.

The URL structure to join a group is:

```console
http://localhost:3001/credentials?group=<group-id>&member=<member-commitment>&provider=eas&redirect_uri=<redirect-url>
```

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #573

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
