### PR TITLE
Fix missing util export

### DIFF
--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -8,7 +8,10 @@ import getWallet from "./getWallet"
 import getBandadaContract, { BandadaContract } from "./getBandadaContract"
 import request from "./request"
 import shortenAddress from "./shortenAddress"
-import { blockchainCredentialSupportedNetworks } from "./getSupportedNetworks"
+import {
+    blockchainCredentialSupportedNetworks,
+    easCredentialSupportedNetworks
+} from "./getSupportedNetworks"
 
 export {
     ApiKeyActions,
@@ -30,5 +33,6 @@ export {
     getContractAddresses,
     SemaphoreABI,
     BandadaABI,
-    blockchainCredentialSupportedNetworks
+    blockchainCredentialSupportedNetworks,
+    easCredentialSupportedNetworks
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes the missing util export that prevents users from using the new easCredentialSupportedNetwork.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
