### PR TITLE
refactor(groupsValidation): throw BadRequestException on invalid treeDepth input

### DIFF
--- a/apps/api/src/app/groups/dto/create-group.dto.ts
+++ b/apps/api/src/app/groups/dto/create-group.dto.ts
@@ -31,8 +31,8 @@ export class CreateGroupDto {
     readonly description: string
 
     @IsNumber()
-    @Min(16)
-    @Max(32)
+    @Min(16, { message: "The tree depth must be between 16 and 32." })
+    @Max(32, { message: "The tree depth must be between 16 and 32." })
     @ApiProperty()
     readonly treeDepth: number
 

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -163,6 +163,12 @@ export class GroupsService {
 
         if (credentials === undefined) credentials = null
 
+        if (treeDepth < 16 || treeDepth > 32) {
+            throw new BadRequestException(
+                "The tree depth must be between 16 and 32."
+            )
+        }
+
         const group = this.groupRepository.create({
             id: _groupId,
             name,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request adds validation to ensure that the `treeDepth` parameter is within the supported range of 16 to 32 inclusive when creating new groups. If an invalid `treeDepth` is provided, the API now returns a clear and descriptive error message by throwing a `BadRequestException`.


<!--- Describe your changes in detail -->

## Related Issue

This pull request addresses #579

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


