### PR TITLE
Add create associated group to api-sdk

### DIFF
--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -179,6 +179,22 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const group = await apiSdk.createGroup(groupCreateDetails, apiKey)
 ```
 
+## Create associated group
+
+\# **createAssociatedGroup**(): _Promise\<Group>_
+
+Creates an associated group to an on-chain group.
+
+```ts
+const onchainGroupId = "1"
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+const associatedGroup = await apiSdk.createAssociatedGroup(
+    onchainGroupId,
+    apiKey
+)
+```
+
 ## Create groups
 
 \# **createGroups**(): _Promise\<Group[]>_

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -202,6 +202,20 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const group = await apiSdk.createGroup(groupCreateDetails, apiKey)
 ```
 
+## Create associated group
+
+\# **createAssociatedGroup**(): _Promise\<Group>_
+
+Creates an associated group to an on-chain group.
+
+```ts
+const onchainGroupId = "1"
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+const associatedGroup = await apiSdk.createAssociatedGroup(onchainGroupId, apiKey)
+```
+
+
 ## Create groups
 
 \# **createGroups**(): _Promise\<Group[]>_

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -212,9 +212,11 @@ Creates an associated group to an on-chain group.
 const onchainGroupId = "1"
 const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 
-const associatedGroup = await apiSdk.createAssociatedGroup(onchainGroupId, apiKey)
+const associatedGroup = await apiSdk.createAssociatedGroup(
+    onchainGroupId,
+    apiKey
+)
 ```
-
 
 ## Create groups
 

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -28,7 +28,8 @@ import {
     getCredentialGroupJoinUrl,
     getAssociatedGroups,
     getGroupsByName,
-    getGroupsByType
+    getGroupsByType,
+    createAssociatedGroup
 } from "./groups"
 import { createInvite, getInvite } from "./invites"
 
@@ -197,6 +198,21 @@ export default class ApiSdk {
         )
 
         return groups
+    }
+
+    /**
+     * Creates an associated group to an on-chain group using the API key.
+     * @param groupId The group id of the on-chain group.
+     * @param apiKey The API key of the admin of the group.
+     * @returns The created associated group.
+     */
+    async createAssociatedGroup(
+        groupId: string,
+        apiKey: string
+    ): Promise<Group> {
+        const group = await createAssociatedGroup(this._config, groupId, apiKey)
+
+        return group[0]
     }
 
     /**

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -227,6 +227,38 @@ export async function createGroups(
 }
 
 /**
+ * Creates an associated group to an on-chain group.
+ * @param groupId The group id.
+ * @param apiKey API Key of the admin.
+ * @returns The created associated group.
+ */
+export async function createAssociatedGroup(
+    config: object,
+    groupId: string,
+    apiKey: string
+): Promise<Group> {
+    const groupCreationDetails = {
+        name: groupId,
+        description: `This group is associated to the on-chain group ${groupId}`,
+        type: "on-chain",
+        treeDepth: 16,
+        fingerprintDuration: 3600
+    }
+
+    const newConfig: any = {
+        method: "post",
+        data: groupCreationDetails,
+        ...config
+    }
+
+    newConfig.headers["x-api-key"] = apiKey
+
+    const req = await request(url, newConfig)
+
+    return req
+}
+
+/**
  * Removes the group.
  * @param groupId The group id.
  * @param apiKey API Key of the admin.

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -245,6 +245,39 @@ describe("Bandada API SDK", () => {
                     JSON.stringify(expectedGroup.credentials)
                 )
             })
+            it("Should create an associated group", async () => {
+                const groupId = "1"
+                const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: groupId,
+                            description: `This is an associated group to the on-chain group ${groupId}`,
+                            type: "on-chain",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: [],
+                            credentials: null
+                        }
+                    ])
+                )
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const group: Group = await apiSdk.createAssociatedGroup(
+                    groupId,
+                    apiKey
+                )
+
+                expect(group.name).toBe(groupId)
+                expect(group.treeDepth).toBe(16)
+                expect(group.fingerprintDuration).toBe(3600)
+                expect(group.members).toHaveLength(0)
+                expect(group.credentials).toBeNull()
+            })
         })
         describe("#createGroups", () => {
             it("Should create the groups", async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces a new feature that allows users to create associated group by using api-sdk.

Example:
```ts
const onchainGroupId = "1"
const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"

const associatedGroup = await apiSdk.createAssociatedGroup(onchainGroupId, apiKey)
```

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

