### PR TITLE
feat: redeemInvite API SDK

### DIFF
--- a/apps/api/src/app/invites/dto/redeem-invite.dto.ts
+++ b/apps/api/src/app/invites/dto/redeem-invite.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { IsNumberString, IsString, Length } from "class-validator"
+
+export class RedeemInviteDto {
+    @IsString()
+    @Length(8)
+    @ApiProperty()
+    readonly inviteCode: string
+
+    @IsString()
+    @Length(32)
+    @IsNumberString()
+    @ApiProperty()
+    readonly groupId: string
+}

--- a/apps/api/src/app/invites/invites.controller.ts
+++ b/apps/api/src/app/invites/invites.controller.ts
@@ -72,4 +72,19 @@ export class InvitesController {
 
         return mapEntity(invite)
     }
+
+    @Post("redeem/:code/group/:group")
+    @ApiOperation({ description: "Redeems a specific invite." })
+    @ApiCreatedResponse({ type: InviteResponse })
+    async redeemInvite(
+        @Param("code") inviteCode: string,
+        @Param("group") groupId: string
+    ): Promise<InviteResponse> {
+        const invite = await this.invitesService.redeemInvite(
+            inviteCode,
+            groupId
+        )
+
+        return mapEntity(invite)
+    }
 }

--- a/apps/api/src/app/invites/invites.controller.ts
+++ b/apps/api/src/app/invites/invites.controller.ts
@@ -5,6 +5,7 @@ import {
     Headers,
     NotImplementedException,
     Param,
+    Patch,
     Post,
     Req
 } from "@nestjs/common"
@@ -22,6 +23,7 @@ import { CreateInviteDto } from "./dto/create-invite.dto"
 import { Invite } from "./entities/invite.entity"
 import { InvitesService } from "./invites.service"
 import { mapEntity } from "../utils"
+import { RedeemInviteDto } from "./dto/redeem-invite.dto"
 
 @ApiTags("invites")
 @Controller("invites")
@@ -73,15 +75,15 @@ export class InvitesController {
         return mapEntity(invite)
     }
 
-    @Post("redeem/:code/group/:group")
+    @Patch("redeem")
+    @ApiBody({ type: RedeemInviteDto })
     @ApiHeader({ name: "x-api-key", required: true })
     @ApiOperation({ description: "Redeems a specific invite." })
     @ApiCreatedResponse({ type: InviteResponse })
     async redeemInvite(
         @Headers() headers: Headers,
         @Req() req: Request,
-        @Param("code") inviteCode: string,
-        @Param("group") groupId: string
+        @Body() { inviteCode, groupId }: RedeemInviteDto
     ): Promise<InviteResponse> {
         let invite: Invite
 

--- a/apps/api/src/app/invites/invites.service.ts
+++ b/apps/api/src/app/invites/invites.service.ts
@@ -121,6 +121,7 @@ export class InvitesService {
      * Redeems an invite by consuming its code. Every invite
      * can be used only once.
      * @param inviteCode Invite code to be redeemed.
+     * @param groupId Group id.
      * @returns The updated invite.
      */
     async redeemInvite(inviteCode: string, groupId: string): Promise<Invite> {
@@ -147,6 +148,42 @@ export class InvitesService {
         invite.isRedeemed = true
 
         return this.inviteRepository.save(invite)
+    }
+
+    /**
+     * Redeems an invite by using API Key.
+     * @param inviteCode Invite code to be redeemed.
+     * @param groupId Group id.
+     * @param apiKey The API Key.
+     * @returns The updated invite.
+     */
+    async redeemInviteWithApiKey(
+        inviteCode: string,
+        groupId: string,
+        apiKey: string
+    ) {
+        await getAndCheckAdmin(this.adminsService, apiKey, groupId)
+
+        return this.redeemInvite(inviteCode, groupId)
+    }
+
+    /**
+     * Redeems an invite manually without using API Key.
+     * @param inviteCode Invite code to be redeemed.
+     * @param groupId Group id.
+     * @param adminId Group admin id.
+     * @returns The updated invite.
+     */
+    async redeemInviteKeyManually(
+        inviteCode: string,
+        groupId: string,
+        adminId: string
+    ) {
+        const admin = await this.adminsService.findOne({ id: adminId })
+
+        if (!admin) throw new BadRequestException(`You are not an admin`)
+
+        return this.redeemInvite(inviteCode, groupId)
     }
 
     /**

--- a/apps/client/src/api/bandadaAPI.ts
+++ b/apps/client/src/api/bandadaAPI.ts
@@ -72,3 +72,22 @@ export async function addMemberByInviteCode(
         return null
     }
 }
+
+export async function redeemInvite(
+    inviteCode: string,
+    groupId: string
+): Promise<Invite | null> {
+    try {
+        return await api.redeemInvite(inviteCode, groupId)
+    } catch (error: any) {
+        console.error(error)
+
+        if (error.response) {
+            alert(error.response.statusText)
+        } else {
+            alert("Some error occurred!")
+        }
+
+        return null
+    }
+}

--- a/apps/client/src/api/bandadaAPI.ts
+++ b/apps/client/src/api/bandadaAPI.ts
@@ -1,6 +1,8 @@
 import { ApiSdk, Group, Invite } from "@bandada/api-sdk"
+import { request } from "@bandada/utils"
 
 const api = new ApiSdk(import.meta.env.VITE_API_URL)
+const API_URL = import.meta.env.VITE_API_URL
 
 export async function getInvite(inviteCode: string): Promise<Invite | null> {
     try {
@@ -78,7 +80,12 @@ export async function redeemInvite(
     groupId: string
 ): Promise<Invite | null> {
     try {
-        return await api.redeemInvite(inviteCode, groupId)
+        return await request(
+            `${API_URL}/invites/redeem/${inviteCode}/group/${groupId}`,
+            {
+                method: "post"
+            }
+        )
     } catch (error: any) {
         console.error(error)
 

--- a/apps/client/src/pages/home.tsx
+++ b/apps/client/src/pages/home.tsx
@@ -118,6 +118,10 @@ export default function HomePage(): JSX.Element {
                         )
 
                         await semaphore.addMember(group.id, identityCommitment)
+                        await bandadaAPI.redeemInvite(
+                            inviteCode,
+                            invite.group.id
+                        )
                     } catch (error) {
                         alert(
                             "Some error occurred! Check if you're on Sepolia network and the transaction is signed and completed"

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -521,6 +521,19 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const invite = await apiSdk.getInvite(inviteCode)
 ```
 
+## Redeem invite
+
+\# **redeemInvite**(): _Promise\<Invite>_
+
+Redeems a specific invite.
+
+```ts
+const groupId = "10402173435763029700781503965100"
+const inviteCode = "C5VAG4HD"
+
+const invite = await apiSdk.redeemInvite(inviteCode, groupId)
+```
+
 ## Get credential group join URL
 
 \# **getCredentialGroupJoinUrl**(): _string_

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -31,7 +31,7 @@ import {
     getGroupsByType,
     createAssociatedGroup
 } from "./groups"
-import { createInvite, getInvite } from "./invites"
+import { createInvite, getInvite, redeemInvite } from "./invites"
 
 export default class ApiSdk {
     private _url: string
@@ -415,6 +415,18 @@ export default class ApiSdk {
      */
     async getInvite(inviteCode: string): Promise<Invite> {
         const invite = await getInvite(this._config, inviteCode)
+
+        return invite
+    }
+
+    /**
+     * Redeems a specific invite.
+     * @param inviteCode Invite code.
+     * @param groupId Group id.
+     * @returns The updated invite.
+     */
+    async redeemInvite(inviteCode: string, groupId: string): Promise<Invite> {
+        const invite = await redeemInvite(this._config, inviteCode, groupId)
 
         return invite
     }

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -423,10 +423,20 @@ export default class ApiSdk {
      * Redeems a specific invite.
      * @param inviteCode Invite code.
      * @param groupId Group id.
+     * @param apiKey The api key.
      * @returns The updated invite.
      */
-    async redeemInvite(inviteCode: string, groupId: string): Promise<Invite> {
-        const invite = await redeemInvite(this._config, inviteCode, groupId)
+    async redeemInvite(
+        inviteCode: string,
+        groupId: string,
+        apiKey: string
+    ): Promise<Invite> {
+        const invite = await redeemInvite(
+            this._config,
+            inviteCode,
+            groupId,
+            apiKey
+        )
 
         return invite
     }

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -1151,6 +1151,45 @@ describe("Bandada API SDK", () => {
                 expect(invite.group).toStrictEqual(group)
             })
         })
+
+        describe("# redeemInvite", () => {
+            it("Should redeem an invite", async () => {
+                const groupId = "95633257675970239314311768035433"
+                const groupName = "Group 1"
+                const group = {
+                    id: groupId,
+                    name: groupName,
+                    description: "This is Group 1",
+                    type: "off-chain",
+                    adminId:
+                        "0x63229164c457584616006e31d1e171e6cdd4163695bc9c4bf0227095998ffa4c",
+                    treeDepth: 16,
+                    fingerprintDuration: 3600,
+                    credentials: null,
+                    apiEnabled: false,
+                    apiKey: null,
+                    createdAt: "2023-08-09T18:09:53.000Z",
+                    updatedAt: "2023-08-09T18:09:53.000Z"
+                }
+                const inviteCode = "C5VAG4HD"
+                const inviteCreatedAt = "2023-08-09T18:10:02.000Z"
+
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve({
+                        code: inviteCode,
+                        isRedeemed: true,
+                        createdAt: inviteCreatedAt,
+                        group
+                    })
+                )
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const invite = await apiSdk.redeemInvite(inviteCode, groupId)
+
+                expect(invite.code).toBe(inviteCode)
+                expect(invite.isRedeemed).toBe(true)
+            })
+        })
     })
     describe("Check Parameter", () => {
         describe("Should not throw an error if the parameter has the expected type", () => {

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -1171,6 +1171,7 @@ describe("Bandada API SDK", () => {
                     createdAt: "2023-08-09T18:09:53.000Z",
                     updatedAt: "2023-08-09T18:09:53.000Z"
                 }
+                const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
                 const inviteCode = "C5VAG4HD"
                 const inviteCreatedAt = "2023-08-09T18:10:02.000Z"
 
@@ -1184,7 +1185,11 @@ describe("Bandada API SDK", () => {
                 )
 
                 const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
-                const invite = await apiSdk.redeemInvite(inviteCode, groupId)
+                const invite = await apiSdk.redeemInvite(
+                    inviteCode,
+                    groupId,
+                    apiKey
+                )
 
                 expect(invite.code).toBe(inviteCode)
                 expect(invite.isRedeemed).toBe(true)

--- a/libs/api-sdk/src/invites.ts
+++ b/libs/api-sdk/src/invites.ts
@@ -53,10 +53,14 @@ export async function redeemInvite(
     groupId: string,
     apiKey: string
 ): Promise<Invite> {
-    const requestUrl = `${url}/redeem/${inviteCode}/group/${groupId}`
+    const requestUrl = `${url}/redeem`
 
     const newConfig: any = {
-        method: "post",
+        method: "patch",
+        data: {
+            inviteCode,
+            groupId
+        },
         ...config
     }
 

--- a/libs/api-sdk/src/invites.ts
+++ b/libs/api-sdk/src/invites.ts
@@ -46,3 +46,20 @@ export async function createInvite(
 
     return req
 }
+
+export async function redeemInvite(
+    config: object,
+    inviteCode: string,
+    groupId: string
+): Promise<Invite> {
+    const requestUrl = `${url}/redeem/${inviteCode}/group/${groupId}`
+
+    const newConfig: any = {
+        method: "post",
+        ...config
+    }
+
+    const req = await request(requestUrl, newConfig)
+
+    return req
+}

--- a/libs/api-sdk/src/invites.ts
+++ b/libs/api-sdk/src/invites.ts
@@ -50,7 +50,8 @@ export async function createInvite(
 export async function redeemInvite(
     config: object,
     inviteCode: string,
-    groupId: string
+    groupId: string,
+    apiKey: string
 ): Promise<Invite> {
     const requestUrl = `${url}/redeem/${inviteCode}/group/${groupId}`
 
@@ -58,6 +59,8 @@ export async function redeemInvite(
         method: "post",
         ...config
     }
+
+    newConfig.headers["x-api-key"] = apiKey
 
     const req = await request(requestUrl, newConfig)
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces a new features that allows users to redeem invite via API SDK. This API SDK can used after joining an on-chain group via invite link to mark the invite code as redeemed.

This new feature has been added to client app to showcase the functionality.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Discussed at https://github.com/bandada-infra/bandada/pull/584#discussion_r1824269818

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

