### PR TITLE
feat: invite code validity check

### DIFF
--- a/apps/api/src/app/invites/invites.controller.ts
+++ b/apps/api/src/app/invites/invites.controller.ts
@@ -75,6 +75,16 @@ export class InvitesController {
         return mapEntity(invite)
     }
 
+    @Get("check/:code/group/:groupId")
+    @ApiOperation({ description: "Checks if a specific invite is valid." })
+    @ApiCreatedResponse({ type: Boolean })
+    async checkInvite(
+        @Param("code") inviteCode: string,
+        @Param("groupId") groupId: string
+    ): Promise<boolean> {
+        return this.invitesService.checkInvite(inviteCode, groupId)
+    }
+
     @Patch("redeem")
     @ApiBody({ type: RedeemInviteDto })
     @ApiHeader({ name: "x-api-key", required: true })

--- a/apps/api/src/app/invites/invites.service.test.ts
+++ b/apps/api/src/app/invites/invites.service.test.ts
@@ -367,6 +367,25 @@ describe("InvitesService", () => {
         })
     })
 
+    describe("# checkInvite", () => {
+        it("Should return true if invite is valid", async () => {
+            const { code } = await invitesService.createInvite(
+                { groupId },
+                admin.id
+            )
+
+            const invite = await invitesService.checkInvite(code, groupId)
+
+            expect(invite).toBeTruthy()
+        })
+
+        it("Should return false if invite is invalid", async () => {
+            const invite = await invitesService.checkInvite("12345", groupId)
+
+            expect(invite).toBeFalsy()
+        })
+    })
+
     describe("# redeemInvite", () => {
         let invite: Invite
 

--- a/apps/api/src/app/invites/invites.service.ts
+++ b/apps/api/src/app/invites/invites.service.ts
@@ -118,6 +118,24 @@ export class InvitesService {
     }
 
     /**
+     * Returns boolean value if the invite code is valid.
+     * @param inviteCode Invite code.
+     * @param groupId Group id.
+     * @returns Boolean.
+     */
+    async checkInvite(inviteCode: string, groupId: string): Promise<boolean> {
+        const invite = await this.inviteRepository.findOne({
+            where: {
+                code: inviteCode,
+                group: { id: groupId }
+            },
+            relations: ["group"]
+        })
+
+        return !!invite
+    }
+
+    /**
      * Redeems an invite by consuming its code. Every invite
      * can be used only once.
      * @param inviteCode Invite code to be redeemed.

--- a/apps/client/src/api/bandadaAPI.ts
+++ b/apps/client/src/api/bandadaAPI.ts
@@ -75,6 +75,27 @@ export async function addMemberByInviteCode(
     }
 }
 
+export async function checkInvite(
+    inviteCode: string,
+    groupId: string
+): Promise<boolean> {
+    try {
+        return await request(
+            `${API_URL}/invites/check/${inviteCode}/group/${groupId}`
+        )
+    } catch (error: any) {
+        console.error(error)
+
+        if (error.response) {
+            alert(error.response.statusText)
+        } else {
+            alert("Some error occurred!")
+        }
+
+        return false
+    }
+}
+
 export async function redeemInvite(
     inviteCode: string,
     groupId: string

--- a/apps/client/src/pages/home.tsx
+++ b/apps/client/src/pages/home.tsx
@@ -63,6 +63,17 @@ export default function HomePage(): JSX.Element {
                     return
                 }
 
+                const isValid = await bandadaAPI.checkInvite(
+                    inviteCode,
+                    invite.group.id
+                )
+
+                if (!isValid) {
+                    setLoading(false)
+                    alert("Invalid invite code")
+                    return
+                }
+
                 const signer = library.getSigner(account)
 
                 const message = `Sign this message to generate your Semaphore identity.`

--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -478,6 +478,19 @@ const groupId = "10402173435763029700781503965100"
 const isValid = await apiSdk.checkInvite(inviteCode, groupId)
 ```
 
+## Redeem invite
+
+\# **redeemInvite**(): _Promise\<Invite>_
+
+Redeems a specific invite.
+
+```ts
+const groupId = "10402173435763029700781503965100"
+const inviteCode = "C5VAG4HD"
+
+const invite = await apiSdk.redeemInvite(inviteCode, groupId)
+```
+
 ## Get credential group join URL
 
 \# **getCredentialGroupJoinUrl**(): _string_

--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -465,6 +465,19 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const invite = await apiSdk.getInvite(inviteCode)
 ```
 
+## Check invite
+
+\# **checkInvite**(): _Promise\<boolean>_
+
+Returns boolean value if the invite code is valid.
+
+```ts
+const inviteCode = "C5VAG4HD"
+const groupId = "10402173435763029700781503965100"
+
+const isValid = await apiSdk.checkInvite(inviteCode, groupId)
+```
+
 ## Get credential group join URL
 
 \# **getCredentialGroupJoinUrl**(): _string_

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -521,6 +521,19 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const invite = await apiSdk.getInvite(inviteCode)
 ```
 
+## Check invite
+
+\# **checkInvite**(): _Promise\<boolean>_
+
+Returns boolean value if the invite code is valid.
+
+```ts
+const inviteCode = "C5VAG4HD"
+const groupId = "10402173435763029700781503965100"
+
+const isValid = await apiSdk.checkInvite(inviteCode, groupId)
+```
+
 ## Redeem invite
 
 \# **redeemInvite**(): _Promise\<Invite>_

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -31,7 +31,7 @@ import {
     getGroupsByType,
     createAssociatedGroup
 } from "./groups"
-import { createInvite, getInvite, redeemInvite } from "./invites"
+import { checkInvite, createInvite, getInvite, redeemInvite } from "./invites"
 
 export default class ApiSdk {
     private _url: string
@@ -417,6 +417,22 @@ export default class ApiSdk {
         const invite = await getInvite(this._config, inviteCode)
 
         return invite
+    }
+
+    /**
+     * Returns boolean value if the invite code is valid.
+     * @param inviteCode Invite code.
+     * @param groupId Group id.
+     * @returns Boolean.
+     */
+    async checkInvite(inviteCode: string, groupId: string): Promise<boolean> {
+        const isInviteValid = await checkInvite(
+            this._config,
+            inviteCode,
+            groupId
+        )
+
+        return isInviteValid
     }
 
     /**

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -1152,6 +1152,25 @@ describe("Bandada API SDK", () => {
             })
         })
 
+        describe("# checkInvite", () => {
+            it("Should check if an invite is valid", async () => {
+                const groupId = "95633257675970239314311768035433"
+                const inviteCode = "C5VAG4HD"
+
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve(true)
+                )
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const isInviteValid = await apiSdk.checkInvite(
+                    inviteCode,
+                    groupId
+                )
+
+                expect(isInviteValid).toBeTruthy()
+            })
+        })
+
         describe("# redeemInvite", () => {
             it("Should redeem an invite", async () => {
                 const groupId = "95633257675970239314311768035433"

--- a/libs/api-sdk/src/invites.ts
+++ b/libs/api-sdk/src/invites.ts
@@ -22,6 +22,24 @@ export async function getInvite(
 }
 
 /**
+ * Returns boolean value if the invite code is valid.
+ * @param inviteCode Invite code.
+ * @param groupId Group id.
+ * @returns Boolean.
+ */
+export async function checkInvite(
+    config: object,
+    inviteCode: string,
+    groupId: string
+): Promise<boolean> {
+    const requestUrl = `${url}/check/${inviteCode}/group/${groupId}`
+
+    const req = await request(requestUrl, config)
+
+    return req
+}
+
+/**
  * Creates one new group invite.
  * @param groupId The group identifier.
  * @param apiKey API Key of the admin.
@@ -47,6 +65,13 @@ export async function createInvite(
     return req
 }
 
+/**
+ * Redeems a specific invite.
+ * @param inviteCode Invite code to be redeemed.
+ * @param groupId Group id.
+ * @param apiKey API Key of the admin.
+ * @returns The updated redeemed invite.
+ */
 export async function redeemInvite(
     config: object,
     inviteCode: string,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces a new feature that allows developers to check the validity of the invite code.

Example usage:
```ts
const inviteCode = "C5VAG4HD"
const groupId = "10402173435763029700781503965100"

const isValid = await apiSdk.checkInvite(inviteCode, groupId)
```

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

