### PR TITLE
Typo Update faq.md

### DIFF
--- a/apps/docs/docs/faq.md
+++ b/apps/docs/docs/faq.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 
 You can ask questions about Bandada in the [PSE Discord](https://discord.com/invite/sF5CT5rzrR), there is a channel for it called `bandada` or by opening a [Bandada Discussion](https://github.com/orgs/bandada-infra/discussions). 
 
-The most frequent asked questions will be listed below.
+The most frequently asked questions will be listed below.
 
 ## How can I start a project using Bandada?
 


### PR DESCRIPTION
## Description

This pull request fixes a typo in the FAQ section of the documentation. The original phrase:

**"The most frequent asked questions will be listed below."**

has been corrected to:

**"The most frequently asked questions will be listed below."**

#### Issue:
The word "frequent" was incorrectly used as an adjective, when it should have been the adverb "frequently" to modify the verb "asked." 

#### Importance:
This correction is important for grammatical accuracy and clarity. The phrase now follows the proper grammatical structure, ensuring the documentation is professional and easy to understand.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
