### PR TITLE
feat(api-sdk): add getMultipleCredentialsGroupJoinUrl

### DIFF
--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -467,3 +467,23 @@ const url = apiSdk.getCredentialGroupJoinUrl(
     redirectUri
 )
 ```
+
+## Get multiple credentials group join URL
+
+\# **getMultipleCredentialGroupJoinUrl**(): _string_
+
+Returns a custom URL string for joining a multiple credentials group.
+
+```ts
+import { DashboardUrl } from "@bandada/api-sdk"
+
+const dashboardUrl = DashboardUrl.DEV
+const groupId = "10402173435763029700781503965100"
+const commitment = "1"
+
+const url = apiSdk.getMultipleCredentialsGroupJoinUrl(
+    dashboardUrl,
+    groupId,
+    commitment
+)
+```

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -490,3 +490,23 @@ const url = apiSdk.getCredentialGroupJoinUrl(
     redirectUri
 )
 ```
+
+## Get multiple credentials group join URL
+
+\# **getMultipleCredentialGroupJoinUrl**(): _string_
+
+Returns a custom URL string for joining a multiple credentials group.
+
+```ts
+import { DashboardUrl } from "@bandada/api-sdk"
+
+const dashboardUrl = DashboardUrl.DEV
+const groupId = "10402173435763029700781503965100"
+const commitment = "1"
+
+const url = apiSdk.getMultipleCredentialsGroupJoinUrl(
+    dashboardUrl,
+    groupId,
+    commitment
+)
+```

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -24,7 +24,8 @@ import {
     removeMembersByApiKey,
     getGroupsByAdminId,
     getGroupsByMemberId,
-    getCredentialGroupJoinUrl
+    getCredentialGroupJoinUrl,
+    getMultipleCredentialsGroupJoinUrl
 } from "./groups"
 import { createInvite, getInvite } from "./invites"
 
@@ -388,6 +389,27 @@ export default class ApiSdk {
             commitment,
             providerName,
             redirectUri
+        )
+
+        return url
+    }
+
+    /**
+     * Generate a custom url for joining a multiple credentials group.
+     * @param dashboardUrl Dashboard base url.
+     * @param groupId Group id.
+     * @param commitment Identity commitment.
+     * @returns Url string.
+     */
+    getMultipleCredentialsGroupJoinUrl(
+        dashboardUrl: DashboardUrl,
+        groupId: string,
+        commitment: string
+    ): string {
+        const url = getMultipleCredentialsGroupJoinUrl(
+            dashboardUrl,
+            groupId,
+            commitment
         )
 
         return url

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -452,3 +452,20 @@ export function getCredentialGroupJoinUrl(
 
     return resultUrl
 }
+
+/**
+ * Generate a custorm url for joining a multiple credentials group.
+ * @param dashboardUrl Dashboard url.
+ * @param groupId Group id.
+ * @param commitment Identity commitment.
+ * @returns Url string.
+ */
+export function getMultipleCredentialsGroupJoinUrl(
+    dashboardUrl: DashboardUrl,
+    groupId: string,
+    commitment: string
+): string {
+    const resultUrl = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&type=multiple`
+
+    return resultUrl
+}

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -857,6 +857,25 @@ describe("Bandada API SDK", () => {
                     expect(res).toBe(url)
                 })
             })
+
+            describe("#getMultipleCredentialGroupJoinUrl", () => {
+                it("Should generate a custom url for joining a multiple credential group", async () => {
+                    const dashboardUrl = DashboardUrl.DEV
+                    const groupId = "10402173435763029700781503965100"
+                    const commitment = "1"
+
+                    const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                    const res = apiSdk.getMultipleCredentialsGroupJoinUrl(
+                        dashboardUrl,
+                        groupId,
+                        commitment
+                    )
+
+                    const url = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&type=multiple`
+
+                    expect(res).toBe(url)
+                })
+            })
         })
     })
     describe("Invites", () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces a new API SDK that allows users to generate a link to join multiple credentials group.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Issue #606 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Opted to add new API SDK method instead of updating the existing `getCredentialGroupJoinUrl` to prevent breaking change.
