### PR TITLE
fix(client): disable input when user joins via an invite link

### DIFF
--- a/apps/client/src/pages/home.tsx
+++ b/apps/client/src/pages/home.tsx
@@ -200,7 +200,9 @@ export default function HomePage(): JSX.Element {
                                 onChange={(event) =>
                                     setInviteCode(event.target.value)
                                 }
-                                disabled={!!_searchParams.get("credentialGroupId")}
+                                disabled={
+                                    !!_searchParams.get("credentialGroupId")
+                                }
                             />
                         </VStack>
 

--- a/apps/client/src/pages/home.tsx
+++ b/apps/client/src/pages/home.tsx
@@ -200,6 +200,7 @@ export default function HomePage(): JSX.Element {
                                 onChange={(event) =>
                                     setInviteCode(event.target.value)
                                 }
+                                disabled={!!_searchParams.get("credentialGroupId")}
                             />
                         </VStack>
 
@@ -213,6 +214,7 @@ export default function HomePage(): JSX.Element {
                                 onChange={(event) =>
                                     setCredentialGroupId(event.target.value)
                                 }
+                                disabled={!!_searchParams.get("inviteCode")}
                             />
                         </VStack>
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request fixes an issue that occurs when a user joins a group via the invite link with an `inviteCode` and clicks the `Credential group ID` input, the invite input gets cleared. And also vice versa.




## Related Issue

Fix: [#270](https://github.com/bandada-infra/bandada/issues/270)

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
