### PR TITLE
feat(client): use API SDK for credential group and multiple credentials group

### DIFF
--- a/apps/client/src/pages/home.tsx
+++ b/apps/client/src/pages/home.tsx
@@ -20,6 +20,8 @@ import { useSearchParams } from "react-router-dom"
 import icon1Image from "../assets/icon1.svg"
 import {
     addMemberByInviteCode,
+    DashboardUrl,
+    getCredentialGroupJoinUrl,
     getGroup,
     getInvite,
     isGroupMember
@@ -129,11 +131,18 @@ export default function HomePage(): JSX.Element {
                 const identity = new Identity(await signer.signMessage(message))
                 const identityCommitment = identity.getCommitment().toString()
 
-                window.open(
-                    `${
-                        import.meta.env.VITE_DASHBOARD_URL
-                    }/credentials?group=${groupId}&member=${identityCommitment}&provider=${providerName}`
+                const dashboardUrl = import.meta.env
+                    .VITE_DASHBOARD_URL as DashboardUrl
+                const credentialGroupJoinUrl = getCredentialGroupJoinUrl(
+                    dashboardUrl,
+                    groupId,
+                    identityCommitment,
+                    providerName
                 )
+
+                if (credentialGroupJoinUrl) {
+                    window.open(credentialGroupJoinUrl, "_blank")
+                }
 
                 setLoading(false)
             }

--- a/apps/client/src/pages/home.tsx
+++ b/apps/client/src/pages/home.tsx
@@ -24,6 +24,7 @@ import {
     getCredentialGroupJoinUrl,
     getGroup,
     getInvite,
+    getMultipleCredentialsGroupJoinUrl,
     isGroupMember
 } from "../utils/api"
 
@@ -121,10 +122,6 @@ export default function HomePage(): JSX.Element {
                     return
                 }
 
-                const providerName = group.credentials.id
-                    .split("_")[0]
-                    .toLowerCase()
-
                 const signer = library.getSigner(account)
 
                 const message = `Sign this message to generate your Semaphore identity.`
@@ -133,12 +130,27 @@ export default function HomePage(): JSX.Element {
 
                 const dashboardUrl = import.meta.env
                     .VITE_DASHBOARD_URL as DashboardUrl
-                const credentialGroupJoinUrl = getCredentialGroupJoinUrl(
-                    dashboardUrl,
-                    groupId,
-                    identityCommitment,
-                    providerName
-                )
+
+                let credentialGroupJoinUrl
+
+                if (Array.isArray(group.credentials.credentials)) {
+                    credentialGroupJoinUrl = getMultipleCredentialsGroupJoinUrl(
+                        dashboardUrl,
+                        groupId,
+                        identityCommitment
+                    )
+                } else {
+                    const providerName = group.credentials.id
+                        .split("_")[0]
+                        .toLowerCase()
+
+                    credentialGroupJoinUrl = getCredentialGroupJoinUrl(
+                        dashboardUrl,
+                        groupId,
+                        identityCommitment,
+                        providerName
+                    )
+                }
 
                 if (credentialGroupJoinUrl) {
                     window.open(credentialGroupJoinUrl, "_blank")

--- a/apps/client/src/utils/api.ts
+++ b/apps/client/src/utils/api.ts
@@ -1,6 +1,8 @@
-import { ApiSdk, Group, Invite } from "@bandada/api-sdk"
+import { ApiSdk, DashboardUrl, Group, Invite } from "@bandada/api-sdk"
 
 const api = new ApiSdk(import.meta.env.VITE_API_URL)
+
+export { DashboardUrl }
 
 export async function getInvite(inviteCode: string): Promise<Invite | null> {
     try {
@@ -60,6 +62,34 @@ export async function addMemberByInviteCode(
 ): Promise<void | null> {
     try {
         return await api.addMemberByInviteCode(groupId, memberId, inviteCode)
+    } catch (error: any) {
+        console.error(error)
+
+        if (error.response) {
+            alert(error.response.statusText)
+        } else {
+            alert("Some error occurred!")
+        }
+
+        return null
+    }
+}
+
+export function getCredentialGroupJoinUrl(
+    dashboardUrl: DashboardUrl,
+    groupId: string,
+    commitment: string,
+    providerName: string,
+    redirectUri?: string
+): string | null {
+    try {
+        return api.getCredentialGroupJoinUrl(
+            dashboardUrl,
+            groupId,
+            commitment,
+            providerName,
+            redirectUri
+        )
     } catch (error: any) {
         console.error(error)
 

--- a/apps/client/src/utils/api.ts
+++ b/apps/client/src/utils/api.ts
@@ -102,3 +102,27 @@ export function getCredentialGroupJoinUrl(
         return null
     }
 }
+
+export function getMultipleCredentialsGroupJoinUrl(
+    dashboardUrl: DashboardUrl,
+    groupId: string,
+    commitment: string
+): string | null {
+    try {
+        return api.getMultipleCredentialsGroupJoinUrl(
+            dashboardUrl,
+            groupId,
+            commitment
+        )
+    } catch (error: any) {
+        console.error(error)
+
+        if (error.response) {
+            alert(error.response.statusText)
+        } else {
+            alert("Some error occurred!")
+        }
+
+        return null
+    }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR updates the current generate join url method in the Client app to use API SDK instead. 

This feature has been added for both credential group and multiple credentials group.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Issue #612 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
