### PR TITLE
feat: redeem invite manually or with api key

### DIFF
--- a/apps/api/src/app/invites/dto/redeem-invite.dto.ts
+++ b/apps/api/src/app/invites/dto/redeem-invite.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { IsNumberString, IsString, Length } from "class-validator"
+
+export class RedeemInviteDto {
+    @IsString()
+    @Length(8)
+    @ApiProperty()
+    readonly inviteCode: string
+
+    @IsString()
+    @Length(32)
+    @IsNumberString()
+    @ApiProperty()
+    readonly groupId: string
+}

--- a/apps/api/src/app/invites/invites.controller.ts
+++ b/apps/api/src/app/invites/invites.controller.ts
@@ -5,6 +5,7 @@ import {
     Headers,
     NotImplementedException,
     Param,
+    Patch,
     Post,
     Req
 } from "@nestjs/common"
@@ -22,6 +23,7 @@ import { CreateInviteDto } from "./dto/create-invite.dto"
 import { Invite } from "./entities/invite.entity"
 import { InvitesService } from "./invites.service"
 import { mapEntity } from "../utils"
+import { RedeemInviteDto } from "./dto/redeem-invite.dto"
 
 @ApiTags("invites")
 @Controller("invites")
@@ -69,6 +71,39 @@ export class InvitesController {
         @Param("code") inviteCode: string
     ): Promise<InviteResponse> {
         const invite = await this.invitesService.getInvite(inviteCode)
+
+        return mapEntity(invite)
+    }
+
+    @Patch("redeem")
+    @ApiBody({ type: RedeemInviteDto })
+    @ApiHeader({ name: "x-api-key", required: true })
+    @ApiOperation({ description: "Redeems a specific invite." })
+    @ApiCreatedResponse({ type: InviteResponse })
+    async redeemInvite(
+        @Headers() headers: Headers,
+        @Req() req: Request,
+        @Body() { inviteCode, groupId }: RedeemInviteDto
+    ): Promise<InviteResponse> {
+        let invite: Invite
+
+        const apiKey = headers["x-api-key"] as string
+
+        if (apiKey) {
+            invite = await this.invitesService.redeemInviteWithApiKey(
+                inviteCode,
+                groupId,
+                apiKey
+            )
+        } else if (req.session.adminId) {
+            invite = await this.invitesService.redeemInviteKeyManually(
+                inviteCode,
+                groupId,
+                req.session.adminId
+            )
+        } else {
+            throw new NotImplementedException()
+        }
 
         return mapEntity(invite)
     }

--- a/apps/api/src/app/invites/invites.service.test.ts
+++ b/apps/api/src/app/invites/invites.service.test.ts
@@ -396,6 +396,118 @@ describe("InvitesService", () => {
         })
     })
 
+    describe("# redeemInviteWithApiKey", () => {
+        it("Should redeem an invite with api key", async () => {
+            await adminsService.updateApiKey(admin.id, ApiKeyActions.Enable)
+
+            const invite = await invitesService.createInvite(
+                { groupId },
+                admin.id
+            )
+
+            const { isRedeemed: redeemed } =
+                await invitesService.redeemInviteWithApiKey(
+                    invite.code,
+                    groupId,
+                    admin.apiKey
+                )
+
+            expect(redeemed).toBeTruthy()
+        })
+
+        it("Should not reddem an invite if the given api key is invalid", async () => {
+            const invite = await invitesService.createInvite(
+                { groupId },
+                admin.id
+            )
+
+            const fun = invitesService.redeemInviteWithApiKey(
+                invite.code,
+                groupId,
+                "wrong-apikey"
+            )
+
+            await expect(fun).rejects.toThrow(
+                `Invalid API key or invalid admin for the group '${groupId}'`
+            )
+        })
+
+        it("Should not redeem an invite if the given api key does not belong to an admin", async () => {
+            const invite = await invitesService.createInvite(
+                { groupId },
+                admin.id
+            )
+
+            const oldApiKey = admin.apiKey
+
+            await adminsService.updateApiKey(admin.id, ApiKeyActions.Generate)
+
+            const fun = invitesService.redeemInviteWithApiKey(
+                invite.code,
+                groupId,
+                oldApiKey
+            )
+
+            await expect(fun).rejects.toThrow(
+                `Invalid API key or invalid admin for the group '${groupId}'`
+            )
+        })
+
+        it("Should not redeem an invite if the given api key is disabled", async () => {
+            const invite = await invitesService.createInvite(
+                { groupId },
+                admin.id
+            )
+
+            await adminsService.updateApiKey(admin.id, ApiKeyActions.Disable)
+
+            admin = await adminsService.findOne({ id: admin.id })
+
+            const fun = invitesService.redeemInviteWithApiKey(
+                invite.code,
+                groupId,
+                admin.apiKey
+            )
+
+            await expect(fun).rejects.toThrow(
+                `Invalid API key or API access not enabled for admin '${admin.id}'`
+            )
+        })
+    })
+
+    describe("# redeemInviteKeyManually", () => {
+        it("Should redeem an invite manually", async () => {
+            const invite = await invitesService.createInvite(
+                { groupId },
+                admin.id
+            )
+
+            const { isRedeemed: redeemed } =
+                await invitesService.redeemInviteKeyManually(
+                    invite.code,
+                    groupId,
+                    admin.id
+                )
+
+            expect(redeemed).toBeTruthy()
+        })
+
+        it("Should not redeem an invite if the given identifier does not belong to an admin", async () => {
+            const invite = await invitesService.createInvite(
+                { groupId },
+                admin.id
+            )
+
+            const fun = invitesService.redeemInviteKeyManually(
+                invite.code,
+                groupId,
+                "wrong-admin"
+            )
+
+            await expect(fun).rejects.toThrow("You are not an admin")
+        })
+    })
+
     describe("# generateCode", () => {
         it("Should generate a random code with 8 characters", async () => {
             const result = (invitesService as any).generateCode()

--- a/apps/api/src/app/invites/invites.service.ts
+++ b/apps/api/src/app/invites/invites.service.ts
@@ -150,6 +150,42 @@ export class InvitesService {
     }
 
     /**
+     * Redeems an invite by using API Key.
+     * @param inviteCode Invite code to be redeemed.
+     * @param groupId Group id.
+     * @param apiKey The API Key.
+     * @returns The updated invite.
+     */
+    async redeemInviteWithApiKey(
+        inviteCode: string,
+        groupId: string,
+        apiKey: string
+    ) {
+        await getAndCheckAdmin(this.adminsService, apiKey, groupId)
+
+        return this.redeemInvite(inviteCode, groupId)
+    }
+
+    /**
+     * Redeems an invite manually without using API Key.
+     * @param inviteCode Invite code to be redeemed.
+     * @param groupId Group id.
+     * @param adminId Group admin id.
+     * @returns The updated invite.
+     */
+    async redeemInviteKeyManually(
+        inviteCode: string,
+        groupId: string,
+        adminId: string
+    ) {
+        const admin = await this.adminsService.findOne({ id: adminId })
+
+        if (!admin) throw new BadRequestException(`You are not an admin`)
+
+        return this.redeemInvite(inviteCode, groupId)
+    }
+
+    /**
      * Generates a random code with a given number of characters.
      * The list of available characters have been chosen to be human readable.
      * @param length Number of characters.

--- a/apps/api/src/app/invites/invites.service.ts
+++ b/apps/api/src/app/invites/invites.service.ts
@@ -146,7 +146,11 @@ export class InvitesService {
 
         invite.isRedeemed = true
 
-        return this.inviteRepository.save(invite)
+        await this.inviteRepository.save(invite)
+
+        Logger.log(`InvitesService: invite '${invite.code}' has been redeemed`)
+
+        return invite
     }
 
     /**

--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -453,9 +453,9 @@ Redeems a specific invite.
 ```ts
 const groupId = "10402173435763029700781503965100"
 const inviteCode = "C5VAG4HD"
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 
-const invite = await apiSdk.redeemInvite(inviteCode, groupId)
-```
+const invite = await apiSdk.redeemInvite(inviteCode, groupId, apiKey)
 
 ## Get credential group join URL
 

--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -444,6 +444,19 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const invite = await apiSdk.getInvite(inviteCode)
 ```
 
+## Redeem invite
+
+\# **redeemInvite**(): _Promise\<Invite>_
+
+Redeems a specific invite.
+
+```ts
+const groupId = "10402173435763029700781503965100"
+const inviteCode = "C5VAG4HD"
+
+const invite = await apiSdk.redeemInvite(inviteCode, groupId)
+```
+
 ## Get credential group join URL
 
 \# **getCredentialGroupJoinUrl**(): _string_

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -476,9 +476,9 @@ Redeems a specific invite.
 ```ts
 const groupId = "10402173435763029700781503965100"
 const inviteCode = "C5VAG4HD"
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 
-const invite = await apiSdk.redeemInvite(inviteCode, groupId)
-```
+const invite = await apiSdk.redeemInvite(inviteCode, groupId, apiKey)
 
 ## Get credential group join URL
 

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -486,7 +486,6 @@ const invite = await apiSdk.redeemInvite(inviteCode, groupId, apiKey)
 
 Returns a custom URL string for joining a credential group.
 
-```ts
 import { DashboardUrl } from "@bandada/api-sdk"
 
 const dashboardUrl = DashboardUrl.DEV

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -467,6 +467,19 @@ const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 const invite = await apiSdk.getInvite(inviteCode)
 ```
 
+## Redeem invite
+
+\# **redeemInvite**(): _Promise\<Invite>_
+
+Redeems a specific invite.
+
+```ts
+const groupId = "10402173435763029700781503965100"
+const inviteCode = "C5VAG4HD"
+
+const invite = await apiSdk.redeemInvite(inviteCode, groupId)
+```
+
 ## Get credential group join URL
 
 \# **getCredentialGroupJoinUrl**(): _string_

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -27,7 +27,7 @@ import {
     getCredentialGroupJoinUrl,
     getMultipleCredentialsGroupJoinUrl
 } from "./groups"
-import { createInvite, getInvite } from "./invites"
+import { createInvite, getInvite, redeemInvite } from "./invites"
 
 export default class ApiSdk {
     private _url: string
@@ -363,6 +363,28 @@ export default class ApiSdk {
      */
     async getInvite(inviteCode: string): Promise<Invite> {
         const invite = await getInvite(this._config, inviteCode)
+
+        return invite
+    }
+
+    /**
+     * Redeems a specific invite.
+     * @param inviteCode Invite code.
+     * @param groupId Group id.
+     * @param apiKey The api key.
+     * @returns The updated invite.
+     */
+    async redeemInvite(
+        inviteCode: string,
+        groupId: string,
+        apiKey: string
+    ): Promise<Invite> {
+        const invite = await redeemInvite(
+            this._config,
+            inviteCode,
+            groupId,
+            apiKey
+        )
 
         return invite
     }

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -957,6 +957,50 @@ describe("Bandada API SDK", () => {
                 expect(invite.group).toStrictEqual(group)
             })
         })
+
+        describe("# redeemInvite", () => {
+            it("Should redeem an invite", async () => {
+                const groupId = "95633257675970239314311768035433"
+                const groupName = "Group 1"
+                const group = {
+                    id: groupId,
+                    name: groupName,
+                    description: "This is Group 1",
+                    type: "off-chain",
+                    adminId:
+                        "0x63229164c457584616006e31d1e171e6cdd4163695bc9c4bf0227095998ffa4c",
+                    treeDepth: 16,
+                    fingerprintDuration: 3600,
+                    credentials: null,
+                    apiEnabled: false,
+                    apiKey: null,
+                    createdAt: "2023-08-09T18:09:53.000Z",
+                    updatedAt: "2023-08-09T18:09:53.000Z"
+                }
+                const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+                const inviteCode = "C5VAG4HD"
+                const inviteCreatedAt = "2023-08-09T18:10:02.000Z"
+
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve({
+                        code: inviteCode,
+                        isRedeemed: true,
+                        createdAt: inviteCreatedAt,
+                        group
+                    })
+                )
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const invite = await apiSdk.redeemInvite(
+                    inviteCode,
+                    groupId,
+                    apiKey
+                )
+
+                expect(invite.code).toBe(inviteCode)
+                expect(invite.isRedeemed).toBe(true)
+            })
+        })
     })
     describe("Check Parameter", () => {
         describe("Should not throw an error if the parameter has the expected type", () => {

--- a/libs/api-sdk/src/invites.ts
+++ b/libs/api-sdk/src/invites.ts
@@ -46,3 +46,34 @@ export async function createInvite(
 
     return req
 }
+
+/**
+ * Redeems a specific invite.
+ * @param inviteCode Invite code to be redeemed.
+ * @param groupId Group id.
+ * @param apiKey API Key of the admin.
+ * @returns The updated redeemed invite.
+ */
+export async function redeemInvite(
+    config: object,
+    inviteCode: string,
+    groupId: string,
+    apiKey: string
+): Promise<Invite> {
+    const requestUrl = `${url}/redeem`
+
+    const newConfig: any = {
+        method: "patch",
+        data: {
+            inviteCode,
+            groupId
+        },
+        ...config
+    }
+
+    newConfig.headers["x-api-key"] = apiKey
+
+    const req = await request(requestUrl, newConfig)
+
+    return req
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces a new feature for users to redeem their invitation code manually or with their api key.

This new feature is available at api and api-sdk.

(This feature was originally in PR #608 but was ported out so that it could be used earlier.)

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Sample usage:
API
```ts
await invitesService.redeemInviteWithApiKey(
    invite.code,
    groupId,
    admin.apiKey
)

await invitesService.redeemInviteKeyManually(
    invite.code,
    groupId,
    admin.id
)
```
API SDK
```ts
const groupId = "10402173435763029700781503965100"
const inviteCode = "C5VAG4HD"

const invite = await apiSdk.redeemInvite(inviteCode, groupId)
```