### PR TITLE
feat: get group by name

### DIFF
--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -40,13 +40,19 @@ export class GroupsController {
     @Get()
     @ApiQuery({ name: "adminId", required: false, type: String })
     @ApiQuery({ name: "memberId", required: false, type: String })
+    @ApiQuery({ name: "name", required: false, type: String })
     @ApiOperation({ description: "Returns the list of groups." })
     @ApiCreatedResponse({ type: Group, isArray: true })
     async getGroups(
         @Query("adminId") adminId: string,
-        @Query("memberId") memberId: string
+        @Query("memberId") memberId: string,
+        @Query("name") name: string
     ) {
-        const groups = await this.groupsService.getGroups({ adminId, memberId })
+        const groups = await this.groupsService.getGroups({
+            adminId,
+            memberId,
+            name
+        })
         const groupIds = groups.map((group) => group.id)
         const fingerprints = await this.groupsService.getFingerprints(groupIds)
 

--- a/apps/api/src/app/groups/groups.service.test.ts
+++ b/apps/api/src/app/groups/groups.service.test.ts
@@ -266,6 +266,24 @@ describe("GroupsService", () => {
 
             expect(result).toHaveLength(1)
         })
+
+        it("Should return a list of groups by group name", async () => {
+            await groupsService.createGroup(
+                {
+                    name: "OnChainGroup",
+                    description: "This is a description",
+                    treeDepth: 16,
+                    fingerprintDuration: 3600
+                },
+                "admin02"
+            )
+
+            const result = await groupsService.getGroups({
+                name: "OnChainGroup"
+            })
+
+            expect(result).toHaveLength(1)
+        })
     })
 
     describe("# getGroup", () => {

--- a/apps/api/src/app/groups/groups.service.ts
+++ b/apps/api/src/app/groups/groups.service.ts
@@ -820,6 +820,7 @@ export class GroupsService {
     async getGroups(filters?: {
         adminId?: string
         memberId?: string
+        name?: string
     }): Promise<Group[]> {
         let where = {}
 
@@ -834,6 +835,13 @@ export class GroupsService {
                 members: {
                     id: filters.memberId
                 },
+                ...where
+            }
+        }
+
+        if (filters?.name) {
+            where = {
+                name: filters.name,
                 ...where
             }
         }

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -25,7 +25,8 @@ import {
     getGroupsByAdminId,
     getGroupsByMemberId,
     getCredentialGroupJoinUrl,
-    getMultipleCredentialsGroupJoinUrl
+    getMultipleCredentialsGroupJoinUrl,
+    getGroupsByName
 } from "./groups"
 import { createInvite, getInvite } from "./invites"
 
@@ -108,6 +109,17 @@ export default class ApiSdk {
      */
     async getGroupsByMemberId(memberId: string): Promise<Group[]> {
         const groups = await getGroupsByMemberId(this._config, memberId)
+
+        return groups
+    }
+
+    /**
+     * Returns the list of groups by name.
+     * @param name Group name.
+     * @returns List of groups by name.
+     */
+    async getGroupsByName(name: string): Promise<Group[]> {
+        const groups = await getGroupsByName(this._config, name)
 
         return groups
     }

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -96,6 +96,37 @@ export async function getGroupsByMemberId(
 }
 
 /**
+ * Returns the list of groups by name.
+ * @param name Group name.
+ * @returns List of groups by name.
+ */
+export async function getGroupsByName(
+    config: object,
+    name: string
+): Promise<Group[]> {
+    const requestUrl = `${url}?name=${name}`
+
+    let groups = await request(requestUrl, config)
+
+    groups = groups.map((group: any) => {
+        let credentials
+
+        try {
+            credentials = JSON.parse(group.credentials)
+        } catch (error) {
+            credentials = null
+        }
+
+        return {
+            ...group,
+            credentials
+        }
+    })
+
+    return groups
+}
+
+/**
  * Creates one or more groups with the provided details.
  * @param groupsCreationDetails Data to create the groups.
  * @param apiKey API Key of the admin.

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -604,6 +604,57 @@ describe("Bandada API SDK", () => {
                 expect(groups[0].credentials).toBeNull()
             })
         })
+        describe("#getGroupsByName", () => {
+            it("Should return all groups by name", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            type: "off-chain",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: ["1"],
+                            credentials: null
+                        }
+                    ])
+                )
+
+                const name = "Group1"
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups: Group[] = await apiSdk.getGroupsByName(name)
+                expect(groups).toHaveLength(1)
+            })
+            it("Should return all groups by name and null in the credentials that don't have a valid JSON string", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            type: "off-chain",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: ["1"],
+                            credentials: {}
+                        }
+                    ])
+                )
+
+                const name = "Group1"
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups: Group[] = await apiSdk.getGroupsByName(name)
+                expect(groups).toHaveLength(1)
+                expect(groups[0].credentials).toBeNull()
+            })
+        })
         describe("#getGroup", () => {
             it("Should return a group", async () => {
                 requestMocked.mockImplementationOnce(() =>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces a new feature for users to get group by group name.

This feature is available to both api and api-sdk.

(This feature was originally in PR #608 but was ported out so that it could be used earlier.)

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Sample usage:
API
```ts
const groups = await groupsService.getGroups({
    name: "group name"
})
```

API SDK
```ts
const groups = await apiSdk.getGroupsByName("name")
```