### PR TITLE
fix(dashboard): missing credentials and expressions under certain conditions

### DIFF
--- a/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
+++ b/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
@@ -341,6 +341,14 @@ export default function AccessModeStep({
                                                 i.toString()
                                             ])
 
+                                            if (_credentials?.id) {
+                                                delete _credentials.id
+                                            }
+
+                                            if (_credentials?.criteria) {
+                                                delete _credentials.criteria
+                                            }
+
                                             const tempCredential = {
                                                 ..._credentials
                                             }

--- a/apps/dashboard/src/pages/new-group.tsx
+++ b/apps/dashboard/src/pages/new-group.tsx
@@ -28,7 +28,7 @@ export default function NewGroupPage(): JSX.Element {
             setCurrentStep((v) => v + 1)
         }
 
-        if (group.type === "on-chain" && !next) {
+        if (group?.type === "on-chain" && !next) {
             setGroup({ type: "on-chain", fingerprintDuration: 3600 })
         }
     }, [])


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR fixes a bug where a user clicks on credentials then on multiple credentials, the credentials and expressions will not be saved to the multiple credentials group.

This PR also fixes a minor bug on undefined type when checking for group type.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
