### PR TITLE
feat: add redirect uri to `getMultipleCredentialsGroupJoinUrl`

### DIFF
--- a/apps/client/src/utils/api.ts
+++ b/apps/client/src/utils/api.ts
@@ -106,13 +106,15 @@ export function getCredentialGroupJoinUrl(
 export function getMultipleCredentialsGroupJoinUrl(
     dashboardUrl: DashboardUrl,
     groupId: string,
-    commitment: string
+    commitment: string,
+    redirectUri?: string
 ): string | null {
     try {
         return api.getMultipleCredentialsGroupJoinUrl(
             dashboardUrl,
             groupId,
-            commitment
+            commitment,
+            redirectUri
         )
     } catch (error: any) {
         console.error(error)

--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -494,10 +494,12 @@ import { DashboardUrl } from "@bandada/api-sdk"
 const dashboardUrl = DashboardUrl.DEV
 const groupId = "10402173435763029700781503965100"
 const commitment = "1"
+const redirectUri = "http://localhost:3003"
 
 const url = apiSdk.getMultipleCredentialsGroupJoinUrl(
     dashboardUrl,
     groupId,
-    commitment
+    commitment,
+    redirectUri
 )
 ```

--- a/apps/docs/docs/tutorials/api-sdk/groups.md
+++ b/apps/docs/docs/tutorials/api-sdk/groups.md
@@ -273,11 +273,13 @@ import { DashboardUrl } from "@bandada/api-sdk"
 const dashboardUrl = DashboardUrl.DEV
 const groupId = "your-group-id"
 const commitment = "commitment-value"
+const redirectUri = "http://localhost:3003"
 
 const url = apiSdk.getMultipleCredentialsGroupJoinUrl(
     dashboardUrl,
     groupId,
-    commitment
+    commitment,
+    redirectUri
 )
 ```
 

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -517,10 +517,12 @@ import { DashboardUrl } from "@bandada/api-sdk"
 const dashboardUrl = DashboardUrl.DEV
 const groupId = "10402173435763029700781503965100"
 const commitment = "1"
+const redirectUri = "http://localhost:3003"
 
 const url = apiSdk.getMultipleCredentialsGroupJoinUrl(
     dashboardUrl,
     groupId,
-    commitment
+    commitment,
+    redirectUri
 )
 ```

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -421,17 +421,20 @@ export default class ApiSdk {
      * @param dashboardUrl Dashboard base url.
      * @param groupId Group id.
      * @param commitment Identity commitment.
+     * @param redirectUri Redirect uri.
      * @returns Url string.
      */
     getMultipleCredentialsGroupJoinUrl(
         dashboardUrl: DashboardUrl,
         groupId: string,
-        commitment: string
+        commitment: string,
+        redirectUri?: string
     ): string {
         const url = getMultipleCredentialsGroupJoinUrl(
             dashboardUrl,
             groupId,
-            commitment
+            commitment,
+            redirectUri
         )
 
         return url

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -458,14 +458,20 @@ export function getCredentialGroupJoinUrl(
  * @param dashboardUrl Dashboard url.
  * @param groupId Group id.
  * @param commitment Identity commitment.
+ * @param redirectUri Redirect uri.
  * @returns Url string.
  */
 export function getMultipleCredentialsGroupJoinUrl(
     dashboardUrl: DashboardUrl,
     groupId: string,
-    commitment: string
+    commitment: string,
+    redirectUri?: string
 ): string {
-    const resultUrl = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&type=multiple`
+    let resultUrl = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&type=multiple`
+
+    if (redirectUri) {
+        resultUrl += `&redirect_uri=${redirectUri}?redirect=true`
+    }
 
     return resultUrl
 }

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -863,15 +863,17 @@ describe("Bandada API SDK", () => {
                     const dashboardUrl = DashboardUrl.DEV
                     const groupId = "10402173435763029700781503965100"
                     const commitment = "1"
+                    const redirectUri = "http://localhost:3003"
 
                     const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
                     const res = apiSdk.getMultipleCredentialsGroupJoinUrl(
                         dashboardUrl,
                         groupId,
-                        commitment
+                        commitment,
+                        redirectUri
                     )
 
-                    const url = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&type=multiple`
+                    const url = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&type=multiple&redirect_uri=${redirectUri}?redirect=true`
 
                     expect(res).toBe(url)
                 })


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces a new feature that gives users the option to include a redirect uri in `getMultipleCredentialsGroupJoinUrl`.

Developers can use this feature to redirect their users to a specific URL after successfully joining a multiple credential group.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #627 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

