### PR TITLE
feat: add clear button to clear multiple credentials input

### DIFF
--- a/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
+++ b/apps/dashboard/src/components/new-group-stepper/access-mode-step.tsx
@@ -69,6 +69,12 @@ export default function AccessModeStep({
         }
     }, [_accessMode, _validator, _validators])
 
+    const onClear = () => {
+        setCredentials(undefined)
+        setValidators([])
+        setExpression([])
+    }
+
     return (
         <>
             <HStack>
@@ -621,6 +627,14 @@ export default function AccessModeStep({
             )}
 
             <HStack justify="right" pt="20px">
+                <Button
+                    variant="solid"
+                    colorScheme="tertiary"
+                    hidden={_accessMode !== "multiple_credentials"}
+                    onClick={onClear}
+                >
+                    Clear
+                </Button>
                 <Button variant="solid" colorScheme="tertiary" onClick={onBack}>
                     Back
                 </Button>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces a new `Clear` button to clear the credentials and expressions inputs when creating a multiple credentials group at dashboard. 

This button allows users to clear the inputs at one click instead of clicking `Back` to go back a step just to clear the inputs.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #630 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

