### PR TITLE
refactor(groups.tsx): make groups responsive for small and medium screen

### DIFF
--- a/apps/dashboard/src/pages/groups.tsx
+++ b/apps/dashboard/src/pages/groups.tsx
@@ -11,7 +11,8 @@ import {
     InputRightElement,
     Spinner,
     Text,
-    VStack
+    VStack,
+    Stack,
 } from "@chakra-ui/react"
 import { useCallback, useContext, useEffect, useState } from "react"
 import { FiSearch } from "react-icons/fi"
@@ -82,9 +83,9 @@ export default function GroupsPage(): JSX.Element {
                     </Heading>
                 </HStack>
 
-                <HStack justifyContent="space-between" width="100%">
+                <Stack justifyContent="space-between" width="100%" direction={{ base: "column", md: "row" }} spacing={2}>
                     <HStack>
-                        <InputGroup w="300px">
+                        <InputGroup w={{ base: "250px", md: "300px" }}>
                             <InputRightElement h="48px" pointerEvents="none">
                                 <FiSearch />
                             </InputRightElement>
@@ -123,7 +124,7 @@ export default function GroupsPage(): JSX.Element {
                     >
                         Add group
                     </Button>
-                </HStack>
+                </Stack>
 
                 {_isLoading && (
                     <Box pt="100px">
@@ -139,7 +140,7 @@ export default function GroupsPage(): JSX.Element {
 
                 {!_isLoading && _groups.length > 0 && (
                     <Grid
-                        templateColumns="repeat(3, 1fr)"
+                        templateColumns={{ base: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }}
                         gap={10}
                         w="100%"
                         mt="60px"
@@ -186,7 +187,7 @@ export default function GroupsPage(): JSX.Element {
 
                 {!_isLoading && _allCredentialGroups.length > 0 && (
                     <Grid
-                        templateColumns="repeat(3, 1fr)"
+                        templateColumns={{ base: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }}
                         gap={10}
                         w="100%"
                         mt="60px"

--- a/apps/dashboard/src/pages/groups.tsx
+++ b/apps/dashboard/src/pages/groups.tsx
@@ -85,8 +85,8 @@ export default function GroupsPage(): JSX.Element {
 
                 <Stack
                     justifyContent="space-between"
-                    width="100%"
-                    direction={{ base: "column", md: "row" }}
+                    width={{lg: "100%"}}
+                    direction={{ base: "column", lg: "row" }}
                     spacing={2}
                 >
                     <HStack>
@@ -148,10 +148,10 @@ export default function GroupsPage(): JSX.Element {
                         templateColumns={{
                             base: "1fr",
                             md: "repeat(2, 1fr)",
-                            lg: "repeat(3, 1fr)"
+                            xl: "repeat(3, 1fr)"
                         }}
                         gap={10}
-                        w="100%"
+                        w={{md:"100%"}}
                         mt="60px"
                     >
                         {_groups
@@ -199,10 +199,10 @@ export default function GroupsPage(): JSX.Element {
                         templateColumns={{
                             base: "1fr",
                             md: "repeat(2, 1fr)",
-                            lg: "repeat(3, 1fr)"
+                            xl: "repeat(3, 1fr)"
                         }}
                         gap={10}
-                        w="100%"
+                        w={{md:"100%"}}
                         mt="60px"
                     >
                         {_allCredentialGroups

--- a/apps/dashboard/src/pages/groups.tsx
+++ b/apps/dashboard/src/pages/groups.tsx
@@ -12,7 +12,7 @@ import {
     Spinner,
     Text,
     VStack,
-    Stack,
+    Stack
 } from "@chakra-ui/react"
 import { useCallback, useContext, useEffect, useState } from "react"
 import { FiSearch } from "react-icons/fi"
@@ -83,7 +83,12 @@ export default function GroupsPage(): JSX.Element {
                     </Heading>
                 </HStack>
 
-                <Stack justifyContent="space-between" width="100%" direction={{ base: "column", md: "row" }} spacing={2}>
+                <Stack
+                    justifyContent="space-between"
+                    width="100%"
+                    direction={{ base: "column", md: "row" }}
+                    spacing={2}
+                >
                     <HStack>
                         <InputGroup w={{ base: "250px", md: "300px" }}>
                             <InputRightElement h="48px" pointerEvents="none">
@@ -140,7 +145,11 @@ export default function GroupsPage(): JSX.Element {
 
                 {!_isLoading && _groups.length > 0 && (
                     <Grid
-                        templateColumns={{ base: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }}
+                        templateColumns={{
+                            base: "1fr",
+                            md: "repeat(2, 1fr)",
+                            lg: "repeat(3, 1fr)"
+                        }}
                         gap={10}
                         w="100%"
                         mt="60px"
@@ -187,7 +196,11 @@ export default function GroupsPage(): JSX.Element {
 
                 {!_isLoading && _allCredentialGroups.length > 0 && (
                     <Grid
-                        templateColumns={{ base: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }}
+                        templateColumns={{
+                            base: "1fr",
+                            md: "repeat(2, 1fr)",
+                            lg: "repeat(3, 1fr)"
+                        }}
                         gap={10}
                         w="100%"
                         mt="60px"


### PR DESCRIPTION
re #557

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Refactor the UX code to make the groups stack (My groups and All Credential Groups) responsive for small and medium screens.

Also refactors the search bar and add group button to fit them in small/medium screens

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
