### PR TITLE
feat: add getGroupsByGroupIds and addMemberToGroups

### DIFF
--- a/apps/api/src/app/groups/dto/add-member-to-groups.dto.ts
+++ b/apps/api/src/app/groups/dto/add-member-to-groups.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { ArrayNotEmpty, IsArray } from "class-validator"
+
+export class AddMemberToGroupsDto {
+    @IsArray()
+    @ArrayNotEmpty()
+    @ApiProperty()
+    readonly groupIds: string[]
+}

--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -377,7 +377,7 @@ export class GroupsController {
         throw new NotImplementedException()
     }
 
-    @Post("/member/:member")
+    @Post("/members/:member")
     @ApiBody({ type: AddMemberToGroupsDto })
     @ApiHeader({ name: "x-api-key", required: true })
     @ApiCreatedResponse({ isArray: true, type: Group })

--- a/apps/api/src/app/groups/groups.controller.ts
+++ b/apps/api/src/app/groups/groups.controller.ts
@@ -31,6 +31,7 @@ import { UpdateGroupsDto } from "./dto/update-groups.dto"
 import { GroupsService } from "./groups.service"
 import { mapGroupToResponseDTO } from "./groups.utils"
 import { RemoveGroupsDto } from "./dto/remove-groups.dto"
+import { AddMemberToGroupsDto } from "./dto/add-member-to-groups.dto"
 
 @ApiTags("groups")
 @Controller("groups")
@@ -40,15 +41,26 @@ export class GroupsController {
     @Get()
     @ApiQuery({ name: "adminId", required: false, type: String })
     @ApiQuery({ name: "memberId", required: false, type: String })
+    @ApiQuery({
+        name: "groupIds",
+        required: false,
+        type: String,
+        isArray: true
+    })
     @ApiOperation({ description: "Returns the list of groups." })
     @ApiCreatedResponse({ type: Group, isArray: true })
     async getGroups(
         @Query("adminId") adminId: string,
-        @Query("memberId") memberId: string
+        @Query("memberId") memberId: string,
+        @Query("groupIds") groupIds: string[]
     ) {
-        const groups = await this.groupsService.getGroups({ adminId, memberId })
-        const groupIds = groups.map((group) => group.id)
-        const fingerprints = await this.groupsService.getFingerprints(groupIds)
+        const groups = await this.groupsService.getGroups({
+            adminId,
+            memberId,
+            groupIds
+        })
+        const groupsIds = groups.map((group) => group.id)
+        const fingerprints = await this.groupsService.getFingerprints(groupsIds)
 
         return groups.map((group, index) =>
             mapGroupToResponseDTO(group, fingerprints[index])
@@ -363,6 +375,52 @@ export class GroupsController {
         }
 
         throw new NotImplementedException()
+    }
+
+    @Post("/member/:member")
+    @ApiBody({ type: AddMemberToGroupsDto })
+    @ApiHeader({ name: "x-api-key", required: true })
+    @ApiCreatedResponse({ isArray: true, type: Group })
+    @ApiOperation({
+        description:
+            "Adds a member to multiple groups. Requires an API Key in the headers or a valid session."
+    })
+    async addMemberToGroups(
+        @Param("member") memberId: string,
+        @Body() dto: AddMemberToGroupsDto,
+        @Headers() headers: Headers,
+        @Req() req: Request
+    ) {
+        let groups = []
+        const groupsToResponseDTO = []
+
+        const apiKey = headers["x-api-key"] as string
+
+        if (apiKey) {
+            groups = await this.groupsService.addMemberToGroupsWithAPIKey(
+                dto.groupIds,
+                memberId,
+                apiKey
+            )
+        } else if (req.session.adminId) {
+            groups = await this.groupsService.addMemberToGroupsManually(
+                dto.groupIds,
+                memberId,
+                req.session.adminId
+            )
+        } else {
+            throw new NotImplementedException()
+        }
+
+        for await (const group of groups) {
+            const fingerprint = await this.groupsService.getFingerprint(
+                group.id
+            )
+
+            groupsToResponseDTO.push(mapGroupToResponseDTO(group, fingerprint))
+        }
+
+        return groupsToResponseDTO
     }
 
     @Delete(":group/members/:member")

--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -407,7 +407,7 @@ await apiSdk.addMemberByInviteCode(groupId, memberId, inviteCode)
 
 ## Add member to groups using an API Key
 
-\# **addMemberToGroupsByApiKey**(): _Promise\<Group[]>_
+\# **addMemberToGroupsByApiKey**(): _Promise\<void>_
 
 Adds a member to multiple groups using an API Key.
 

--- a/apps/docs/docs/api-sdk.md
+++ b/apps/docs/docs/api-sdk.md
@@ -322,6 +322,21 @@ const memberId = "1"
 const groups = await apiSdk.getGroupsByMemberId(memberId)
 ```
 
+## Get groups by group ids
+
+\# **getGroupByGroupIds**(): _Promise\<Group[]>_
+
+Returns the list of groups by group ids.
+
+```ts
+const groupIds = [
+    "10402173435763029700781503965100",
+    "20402173435763029700781503965200"
+]
+
+const groups = await apiSdk.getGroupsByGroupIds(groupIds)
+```
+
 ## Is group member
 
 \# **isGroupMember**(): _Promise\<boolean>_
@@ -388,6 +403,20 @@ const memberId = "1"
 const inviteCode = "MQYS4UR5"
 
 await apiSdk.addMemberByInviteCode(groupId, memberId, inviteCode)
+```
+
+## Add member to groups using an API Key
+
+\# **addMemberToGroupsByApiKey**(): _Promise\<Group[]>_
+
+Adds a member to multiple groups using an API Key.
+
+```ts
+const groupIds = ["10402173435763029700781503965100", "20402173435763029700781503965200"]
+const memberId = "1"
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+await apiSdk.addMemberToGroupsByApiKey(groupIds, memberId, apiKey)
 ```
 
 ## Remove member using an API Key

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -345,6 +345,21 @@ const memberId = "1"
 const groups = await apiSdk.getGroupsByMemberId(memberId)
 ```
 
+## Get groups by group ids
+
+\# **getGroupByGroupIds**(): _Promise\<Group[]>_
+
+Returns the list of groups by group ids.
+
+```ts
+const groupIds = [
+    "10402173435763029700781503965100",
+    "20402173435763029700781503965200"
+]
+
+const groups = await apiSdk.getGroupsByGroupIds(groupIds)
+```
+
 ## Is group member
 
 \# **isGroupMember**(): _Promise\<boolean>_
@@ -411,6 +426,23 @@ const memberId = "1"
 const inviteCode = "MQYS4UR5"
 
 await apiSdk.addMemberByInviteCode(groupId, memberId, inviteCode)
+```
+
+## Add member to groups using an API Key
+
+\# **addMemberToGroupsByApiKey**(): _Promise\<Group[]>_
+
+Adds a member to multiple groups using an API Key.
+
+```ts
+const groupIds = [
+    "10402173435763029700781503965100",
+    "20402173435763029700781503965200"
+]
+const memberId = "1"
+const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+await apiSdk.addMemberToGroupsByApiKey(groupIds, memberId, apiKey)
 ```
 
 ## Remove member using an API Key

--- a/libs/api-sdk/README.md
+++ b/libs/api-sdk/README.md
@@ -430,7 +430,7 @@ await apiSdk.addMemberByInviteCode(groupId, memberId, inviteCode)
 
 ## Add member to groups using an API Key
 
-\# **addMemberToGroupsByApiKey**(): _Promise\<Group[]>_
+\# **addMemberToGroupsByApiKey**(): _Promise\<void>_
 
 Adds a member to multiple groups using an API Key.
 

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -338,15 +338,13 @@ export default class ApiSdk {
         groupIds: string[],
         memberId: string,
         apiKey: string
-    ): Promise<Group[]> {
-        const groups = await addMemberToGroupsByApiKey(
+    ): Promise<void> {
+        await addMemberToGroupsByApiKey(
             this._config,
             groupIds,
             memberId,
             apiKey
         )
-
-        return groups
     }
 
     /**

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -24,6 +24,7 @@ import {
     removeMembersByApiKey,
     getGroupsByAdminId,
     getGroupsByMemberId,
+    getGroupsByGroupIds,
     getCredentialGroupJoinUrl,
     getMultipleCredentialsGroupJoinUrl,
     addMemberToGroupsByApiKey
@@ -109,6 +110,17 @@ export default class ApiSdk {
      */
     async getGroupsByMemberId(memberId: string): Promise<Group[]> {
         const groups = await getGroupsByMemberId(this._config, memberId)
+
+        return groups
+    }
+
+    /**
+     * Returns the list of groups by group ids.
+     * @param groupIds Group ids.
+     * @returns List of groups by group ids.
+     */
+    async getGroupsByGroupIds(groupIds: string[]): Promise<Group[]> {
+        const groups = await getGroupsByGroupIds(this._config, groupIds)
 
         return groups
     }

--- a/libs/api-sdk/src/apiSdk.ts
+++ b/libs/api-sdk/src/apiSdk.ts
@@ -25,7 +25,8 @@ import {
     getGroupsByAdminId,
     getGroupsByMemberId,
     getCredentialGroupJoinUrl,
-    getMultipleCredentialsGroupJoinUrl
+    getMultipleCredentialsGroupJoinUrl,
+    addMemberToGroupsByApiKey
 } from "./groups"
 import { createInvite, getInvite, redeemInvite } from "./invites"
 
@@ -312,6 +313,28 @@ export default class ApiSdk {
         inviteCode: string
     ): Promise<void> {
         await addMemberByInviteCode(this._config, groupId, memberId, inviteCode)
+    }
+
+    /**
+     * Adds a member to multiple groups using an API Key.
+     * @param groupIds Array of group ids.
+     * @param memberId Member id.
+     * @param apiKey API Key of the admin of the group.
+     * @returns Array of the groups of added member.
+     */
+    async addMemberToGroupsByApiKey(
+        groupIds: string[],
+        memberId: string,
+        apiKey: string
+    ): Promise<Group[]> {
+        const groups = await addMemberToGroupsByApiKey(
+            this._config,
+            groupIds,
+            memberId,
+            apiKey
+        )
+
+        return groups
     }
 
     /**

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -376,6 +376,34 @@ export async function addMemberByInviteCode(
 }
 
 /**
+ * Adds a member to multiple groups.
+ * @param groupIds Array of group ids.
+ * @param memberId Member id.
+ * @param apiKey API Key of the admin.
+ * @returns Array of the groups of added member.
+ */
+export function addMemberToGroupsByApiKey(
+    config: object,
+    groupIds: string[],
+    memberId: string,
+    apiKey: string
+): Promise<Group[]> {
+    const newConfig: any = {
+        method: "post",
+        data: {
+            groupIds
+        },
+        ...config
+    }
+
+    newConfig.headers["x-api-key"] = apiKey
+
+    const req = request(`${url}/member/${memberId}`, newConfig)
+
+    return req
+}
+
+/**
  * Removes a member from a group using an API Key.
  * @param groupId Group id.
  * @param memberId Member id.

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -96,6 +96,41 @@ export async function getGroupsByMemberId(
 }
 
 /**
+ * Returns the list of groups by group ids.
+ * @param groupIds Group ids.
+ * @returns List of groups by group ids.
+ */
+export async function getGroupsByGroupIds(
+    config: object,
+    groupIds: string[]
+): Promise<Group[]> {
+    let requestUrl = `${url}?`
+
+    for (const groupId of groupIds) {
+        requestUrl += `&groupIds=${groupId}`
+    }
+
+    let groups = await request(requestUrl, config)
+
+    groups = groups.map((group: any) => {
+        let credentials
+
+        try {
+            credentials = JSON.parse(group.credentials)
+        } catch (error) {
+            credentials = null
+        }
+
+        return {
+            ...group,
+            credentials
+        }
+    })
+
+    return groups
+}
+
+/**
  * Creates one or more groups with the provided details.
  * @param groupsCreationDetails Data to create the groups.
  * @param apiKey API Key of the admin.

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -422,7 +422,7 @@ export function addMemberToGroupsByApiKey(
     groupIds: string[],
     memberId: string,
     apiKey: string
-): Promise<Group[]> {
+): Promise<void> {
     const newConfig: any = {
         method: "post",
         data: {

--- a/libs/api-sdk/src/groups.ts
+++ b/libs/api-sdk/src/groups.ts
@@ -433,7 +433,7 @@ export function addMemberToGroupsByApiKey(
 
     newConfig.headers["x-api-key"] = apiKey
 
-    const req = request(`${url}/member/${memberId}`, newConfig)
+    const req = request(`${url}/members/${memberId}`, newConfig)
 
     return req
 }

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -604,6 +604,59 @@ describe("Bandada API SDK", () => {
                 expect(groups[0].credentials).toBeNull()
             })
         })
+        describe("getGroupsByGroupIds", () => {
+            it("Should return all groups by group ids", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: [],
+                            credentials: null
+                        }
+                    ])
+                )
+
+                const groupIds = ["10402173435763029700781503965100"]
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups: Group[] = await apiSdk.getGroupsByGroupIds(
+                    groupIds
+                )
+                expect(groups).toHaveLength(1)
+            })
+            it("Should return all groups by group ids and null in the credentials that don't have a valid JSON string", async () => {
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: [],
+                            credentials: {}
+                        }
+                    ])
+                )
+
+                const groupIds = ["10402173435763029700781503965100"]
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups: Group[] = await apiSdk.getGroupsByGroupIds(
+                    groupIds
+                )
+                expect(groups).toHaveLength(1)
+                expect(groups[0].credentials).toBeNull()
+            })
+        })
         describe("#getGroup", () => {
             it("Should return a group", async () => {
                 requestMocked.mockImplementationOnce(() =>

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -795,86 +795,156 @@ describe("Bandada API SDK", () => {
                 )
                 expect(res).toBeUndefined()
             })
-            describe("#removeMemberByApiKey", () => {
-                it("Should remove a member from a group using an API Key", async () => {
-                    requestMocked.mockImplementationOnce(() =>
-                        Promise.resolve()
-                    )
+        })
 
-                    const groupId = "10402173435763029700781503965100"
-                    const memberId = "1"
-                    const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+        describe("#addMemberToGroups", () => {
+            it("Should add a member to multiple groups using an API Key", async () => {
+                const expectedGroups: Array<GroupCreationDetails> = [
+                    {
+                        name: "Group1",
+                        description: "This is a new group",
+                        treeDepth: 16,
+                        fingerprintDuration: 3600
+                    },
+                    {
+                        name: "Group2",
+                        description: "This is a new group",
+                        treeDepth: 32,
+                        fingerprintDuration: 7200
+                    }
+                ]
 
-                    const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
-                    const res = await apiSdk.removeMemberByApiKey(
-                        groupId,
-                        memberId,
-                        apiKey
+                requestMocked.mockImplementationOnce(() =>
+                    Promise.resolve([
+                        {
+                            id: "10402173435763029700781503965100",
+                            name: "Group1",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 16,
+                            fingerprintDuration: 3600,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: ["1"],
+                            credentials: null
+                        },
+                        {
+                            id: "20402173435763029700781503965200",
+                            name: "Group2",
+                            description: "This is a new group",
+                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
+                            treeDepth: 32,
+                            fingerprintDuration: 7200,
+                            createdAt: "2023-07-15T08:21:05.000Z",
+                            members: ["1"],
+                            credentials: null
+                        }
+                    ])
+                )
+
+                const groupIds = [
+                    "10402173435763029700781503965100",
+                    "20402173435763029700781503965200"
+                ]
+                const memberId = "1"
+                const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const groups = await apiSdk.addMemberToGroupsByApiKey(
+                    groupIds,
+                    memberId,
+                    apiKey
+                )
+
+                groups.forEach((group: Group, i: number) => {
+                    expect(group.description).toBe(
+                        expectedGroups[i].description
                     )
-                    expect(res).toBeUndefined()
+                    expect(group.name).toBe(expectedGroups[i].name)
+                    expect(group.treeDepth).toBe(expectedGroups[i].treeDepth)
+                    expect(group.fingerprintDuration).toBe(
+                        expectedGroups[i].fingerprintDuration
+                    )
+                    expect(group.members).toHaveLength(1)
+                    expect(group.credentials).toBeNull()
                 })
             })
+        })
 
-            describe("#removeMembersByApiKey", () => {
-                it("Should remove multiple members from a group using an API Key", async () => {
-                    requestMocked.mockImplementationOnce(() =>
-                        Promise.resolve()
-                    )
+        describe("#removeMemberByApiKey", () => {
+            it("Should remove a member from a group using an API Key", async () => {
+                requestMocked.mockImplementationOnce(() => Promise.resolve())
 
-                    const groupId = "10402173435763029700781503965100"
-                    const memberIds = ["1", "2", "3"]
-                    const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
+                const groupId = "10402173435763029700781503965100"
+                const memberId = "1"
+                const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 
-                    const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
-                    const res = await apiSdk.removeMembersByApiKey(
-                        groupId,
-                        memberIds,
-                        apiKey
-                    )
-                    expect(res).toBeUndefined()
-                })
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const res = await apiSdk.removeMemberByApiKey(
+                    groupId,
+                    memberId,
+                    apiKey
+                )
+                expect(res).toBeUndefined()
             })
+        })
 
-            describe("#getCredentialGroupJoinUrl", () => {
-                it("Should generate a custom url for joining a credential group", async () => {
-                    const dashboardUrl = DashboardUrl.DEV
-                    const groupId = "10402173435763029700781503965100"
-                    const commitment = "1"
-                    const providerName = "github"
-                    const redirectUri = "http://localhost:3003"
+        describe("#removeMembersByApiKey", () => {
+            it("Should remove multiple members from a group using an API Key", async () => {
+                requestMocked.mockImplementationOnce(() => Promise.resolve())
 
-                    const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
-                    const res = apiSdk.getCredentialGroupJoinUrl(
-                        dashboardUrl,
-                        groupId,
-                        commitment,
-                        providerName,
-                        redirectUri
-                    )
+                const groupId = "10402173435763029700781503965100"
+                const memberIds = ["1", "2", "3"]
+                const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 
-                    const url = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}?redirect=true`
-
-                    expect(res).toBe(url)
-                })
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const res = await apiSdk.removeMembersByApiKey(
+                    groupId,
+                    memberIds,
+                    apiKey
+                )
+                expect(res).toBeUndefined()
             })
+        })
 
-            describe("#getMultipleCredentialGroupJoinUrl", () => {
-                it("Should generate a custom url for joining a multiple credential group", async () => {
-                    const dashboardUrl = DashboardUrl.DEV
-                    const groupId = "10402173435763029700781503965100"
-                    const commitment = "1"
+        describe("#getCredentialGroupJoinUrl", () => {
+            it("Should generate a custom url for joining a credential group", async () => {
+                const dashboardUrl = DashboardUrl.DEV
+                const groupId = "10402173435763029700781503965100"
+                const commitment = "1"
+                const providerName = "github"
+                const redirectUri = "http://localhost:3003"
 
-                    const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
-                    const res = apiSdk.getMultipleCredentialsGroupJoinUrl(
-                        dashboardUrl,
-                        groupId,
-                        commitment
-                    )
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const res = apiSdk.getCredentialGroupJoinUrl(
+                    dashboardUrl,
+                    groupId,
+                    commitment,
+                    providerName,
+                    redirectUri
+                )
 
-                    const url = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&type=multiple`
+                const url = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&provider=${providerName}&redirect_uri=${redirectUri}?redirect=true`
 
-                    expect(res).toBe(url)
-                })
+                expect(res).toBe(url)
+            })
+        })
+
+        describe("#getMultipleCredentialGroupJoinUrl", () => {
+            it("Should generate a custom url for joining a multiple credential group", async () => {
+                const dashboardUrl = DashboardUrl.DEV
+                const groupId = "10402173435763029700781503965100"
+                const commitment = "1"
+
+                const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
+                const res = apiSdk.getMultipleCredentialsGroupJoinUrl(
+                    dashboardUrl,
+                    groupId,
+                    commitment
+                )
+
+                const url = `${dashboardUrl}/credentials?group=${groupId}&member=${commitment}&type=multiple`
+
+                expect(res).toBe(url)
             })
         })
     })

--- a/libs/api-sdk/src/index.test.ts
+++ b/libs/api-sdk/src/index.test.ts
@@ -852,47 +852,7 @@ describe("Bandada API SDK", () => {
 
         describe("#addMemberToGroups", () => {
             it("Should add a member to multiple groups using an API Key", async () => {
-                const expectedGroups: Array<GroupCreationDetails> = [
-                    {
-                        name: "Group1",
-                        description: "This is a new group",
-                        treeDepth: 16,
-                        fingerprintDuration: 3600
-                    },
-                    {
-                        name: "Group2",
-                        description: "This is a new group",
-                        treeDepth: 32,
-                        fingerprintDuration: 7200
-                    }
-                ]
-
-                requestMocked.mockImplementationOnce(() =>
-                    Promise.resolve([
-                        {
-                            id: "10402173435763029700781503965100",
-                            name: "Group1",
-                            description: "This is a new group",
-                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
-                            treeDepth: 16,
-                            fingerprintDuration: 3600,
-                            createdAt: "2023-07-15T08:21:05.000Z",
-                            members: ["1"],
-                            credentials: null
-                        },
-                        {
-                            id: "20402173435763029700781503965200",
-                            name: "Group2",
-                            description: "This is a new group",
-                            admin: "0xdf558148e66850ac48dbe2c8119b0eefa7d08bfd19c997c90a142eb97916b847",
-                            treeDepth: 32,
-                            fingerprintDuration: 7200,
-                            createdAt: "2023-07-15T08:21:05.000Z",
-                            members: ["1"],
-                            credentials: null
-                        }
-                    ])
-                )
+                requestMocked.mockImplementationOnce(() => Promise.resolve())
 
                 const groupIds = [
                     "10402173435763029700781503965100",
@@ -902,24 +862,13 @@ describe("Bandada API SDK", () => {
                 const apiKey = "70f07d0d-6aa2-4fe1-b4b9-06c271a641dc"
 
                 const apiSdk: ApiSdk = new ApiSdk(SupportedUrl.DEV)
-                const groups = await apiSdk.addMemberToGroupsByApiKey(
+                const res = await apiSdk.addMemberToGroupsByApiKey(
                     groupIds,
                     memberId,
                     apiKey
                 )
 
-                groups.forEach((group: Group, i: number) => {
-                    expect(group.description).toBe(
-                        expectedGroups[i].description
-                    )
-                    expect(group.name).toBe(expectedGroups[i].name)
-                    expect(group.treeDepth).toBe(expectedGroups[i].treeDepth)
-                    expect(group.fingerprintDuration).toBe(
-                        expectedGroups[i].fingerprintDuration
-                    )
-                    expect(group.members).toHaveLength(1)
-                    expect(group.credentials).toBeNull()
-                })
+                expect(res).toBeUndefined()
             })
         })
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces 2 new features to API and API SDK which allows users to:
- Get groups with multiple group ids.
- Add member to multiple groups.

#### getGroupsByGroupIds:

API
```http
GET http://localhost:3000/groups?groupIds={groupId}&groupIds={groupId}
```
```ts
const groupIds = ["1", "2"]
const groups = await this.groupsService.getGroups(groupIds)
```

API SDK
```ts
const groupIds = ["1", "2"]
const groups = await apiSdk.getGroupsByGroupIds(groupIds)
```

#### addMemberToGroups:
API
```http
POST http://localhost:3000/groups/member/{memberId}
```
```ts
const memberId = "memberId"
const groupIds = ["1", "2"]
const adminId = "adminId"
const apiKey = "apiKey"

const manual = await this.groupsService.addMemberToGroupsManually(groupIds, memberId, adminId)
const api = await this.groupsService.addMemberToGroupsWithApiKey(groupIds, memberId, apiKey)
```

API SDK
```ts
const groupIds = ["1", "2"]
const memberId = "memberId"
const apiKey = "apiKey"

await apiSdk.addMemberToGroupsByApiKey(groupIds, memberId, apiKey)
```

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #633 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

