### PR TITLE
refactor: make group responsive

### DIFF
--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -404,7 +404,7 @@ ${memberIds.join("\n")}
             <Stack
                 mt="30px"
                 align="start"
-                spacing={{base: "6", lg:"14"}}
+                spacing={{ base: "6", lg: "14" }}
                 direction={{ base: "column-reverse", md: "row" }}
             >
                 <VStack
@@ -759,7 +759,10 @@ ${memberIds.join("\n")}
                     borderRadius="8px"
                     width={{ base: "100%", md: "auto" }}
                 >
-                    <Stack justify="space-between" direction={{base:"column", lg: "row"}}>
+                    <Stack
+                        justify="space-between"
+                        direction={{ base: "column", lg: "row" }}
+                    >
                         <Heading fontSize="25px" as="h1">
                             Members
                         </Heading>

--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -404,7 +404,7 @@ ${memberIds.join("\n")}
             <Stack
                 mt="30px"
                 align="start"
-                spacing="2"
+                spacing={{base: "6", lg:"14"}}
                 direction={{ base: "column-reverse", md: "row" }}
             >
                 <VStack

--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -759,7 +759,7 @@ ${memberIds.join("\n")}
                     borderRadius="8px"
                     width={{ base: "100%", md: "auto" }}
                 >
-                    <HStack justify="space-between">
+                    <Stack justify="space-between" direction={{base:"column", lg: "row"}}>
                         <Heading fontSize="25px" as="h1">
                             Members
                         </Heading>
@@ -771,7 +771,7 @@ ${memberIds.join("\n")}
                         >
                             Add member
                         </Button>
-                    </HStack>
+                    </Stack>
 
                     <HStack mt="30px" mb="20px">
                         <InputGroup w="100%">

--- a/apps/dashboard/src/pages/group.tsx
+++ b/apps/dashboard/src/pages/group.tsx
@@ -24,7 +24,8 @@ import {
     useClipboard,
     useDisclosure,
     useToast,
-    VStack
+    VStack,
+    Stack
 } from "@chakra-ui/react"
 import { useCallback, useEffect, useState, useContext } from "react"
 import { CgProfile } from "react-icons/cg"
@@ -400,9 +401,23 @@ ${memberIds.join("\n")}
                 )}
             </VStack>
 
-            <HStack mt="30px" align="start" spacing="14">
-                <VStack flex="1" align="stretch" spacing="6">
-                    <HStack flex="1" spacing="4">
+            <Stack
+                mt="30px"
+                align="start"
+                spacing="2"
+                direction={{ base: "column-reverse", md: "row" }}
+            >
+                <VStack
+                    flex="1"
+                    align="stretch"
+                    spacing="6"
+                    width={{ base: "100%", md: "auto" }}
+                >
+                    <Stack
+                        flex="1"
+                        spacing="4"
+                        direction={{ base: "column", md: "row" }}
+                    >
                         <Box
                             flex="1"
                             bgColor="balticSea.50"
@@ -448,7 +463,7 @@ ${memberIds.join("\n")}
                                 {_group.treeDepth}
                             </Heading>
                         </Box>
-                    </HStack>
+                    </Stack>
                     (
                     <Box
                         bgColor="balticSea.50"
@@ -742,6 +757,7 @@ ${memberIds.join("\n")}
                     borderColor="classicRose.200"
                     borderWidth="1px"
                     borderRadius="8px"
+                    width={{ base: "100%", md: "auto" }}
                 >
                     <HStack justify="space-between">
                         <Heading fontSize="25px" as="h1">
@@ -864,12 +880,18 @@ ${memberIds.join("\n")}
                         ))
                     )}
                     {_group.type === "off-chain" && isGroupAdmin && (
-                        <Flex mt="20px" justify="space-between" align="center">
-                            <ButtonGroup>
+                        <Flex
+                            mt="20px"
+                            justify="space-between"
+                            align="center"
+                            direction={{ base: "column", lg: "row" }}
+                        >
+                            <ButtonGroup width={{ base: "100%", lg: "auto" }}>
                                 <Button
                                     variant="solid"
                                     colorScheme="tertiary"
                                     onClick={handleSelectAll}
+                                    width={{ base: "50%", lg: "auto" }}
                                 >
                                     Select All
                                 </Button>
@@ -877,6 +899,7 @@ ${memberIds.join("\n")}
                                     variant="solid"
                                     colorScheme="tertiary"
                                     onClick={handleDeselectAll}
+                                    width={{ base: "50%", lg: "auto" }}
                                 >
                                     Deselect
                                 </Button>
@@ -886,14 +909,15 @@ ${memberIds.join("\n")}
                                 colorScheme="danger"
                                 isDisabled={_selectedMembers.length === 0}
                                 onClick={() => removeMembers(_selectedMembers)}
-                                size="sm"
+                                width={{ base: "100%", lg: "auto" }}
+                                mt={{ base: "1rem", lg: "0" }}
                             >
                                 Remove Selected Members
                             </Button>
                         </Flex>
                     )}
                 </Box>
-            </HStack>
+            </Stack>
 
             <AddMemberModal
                 isOpen={addMembersModal.isOpen}


### PR DESCRIPTION
re #558

## Description
Make the group page on dashboard responsive for small and medium screens.

Used chakra responsive properties to define base, md and lg behavior 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

For small screens

![image](https://github.com/user-attachments/assets/62e88853-753e-4039-a8b7-7867a3609759)

For medium and large screens

![image](https://github.com/user-attachments/assets/eb093dc0-2378-44f7-b16e-83010a1c2f4f)
