### PR TITLE
refactor: make connected account button responsive for small sreens

### DIFF
--- a/apps/dashboard/src/components/navbar.tsx
+++ b/apps/dashboard/src/components/navbar.tsx
@@ -73,9 +73,11 @@ export default function NavBar(): JSX.Element {
                     >
                         {!isLoggedInAdmin()
                             ? "Unconnected account"
-                            : `Connected as ${shortenAddress(
-                                  address as string
-                              )}`}
+                            : `${
+                                  window.screen.availWidth > 375
+                                      ? "Connected as"
+                                      : ""
+                              } ${shortenAddress(address as string)}`}
                     </Button>
                 </HStack>
             </HStack>

--- a/apps/dashboard/src/components/navbar.tsx
+++ b/apps/dashboard/src/components/navbar.tsx
@@ -1,5 +1,12 @@
 import { shortenAddress } from "@bandada/utils"
-import { Button, Container, Heading, HStack, Image } from "@chakra-ui/react"
+import {
+    Button,
+    Container,
+    Heading,
+    HStack,
+    Image,
+    useMediaQuery
+} from "@chakra-ui/react"
 import { useAccountModal, useConnectModal } from "@rainbow-me/rainbowkit"
 import { useCallback, useContext } from "react"
 import { useAccount } from "wagmi"
@@ -25,10 +32,13 @@ export default function NavBar(): JSX.Element {
         [address, admin]
     )
 
+    const [isWideScreen] = useMediaQuery("(min-width: 426px)")
+
     return (
         <Container maxWidth="container.xl">
             <HStack
                 pt="80px"
+                wrap="wrap"
                 pb="40px"
                 align="center"
                 justify="space-between"
@@ -74,9 +84,7 @@ export default function NavBar(): JSX.Element {
                         {!isLoggedInAdmin()
                             ? "Unconnected account"
                             : `${
-                                  window.screen.availWidth > 375
-                                      ? "Connected as"
-                                      : ""
+                                  isWideScreen ? "Connected as" : ""
                               } ${shortenAddress(address as string)}`}
                     </Button>
                 </HStack>


### PR DESCRIPTION
re #641

## Description

Make the connected account button responsive for small screens to prevent overlapping with bandada logo

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Other information

Small screens
![image](https://github.com/user-attachments/assets/d370edc1-6b0b-4236-956e-7c5f81f44643)

Medium/large screens
![image](https://github.com/user-attachments/assets/5d60c108-f343-4519-bc91-ab745a8af32c)

