### PR TITLE
fix: Fix incorrect URL in bugs.url field

### DIFF
--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -19,7 +19,7 @@
     "repository": "https://github.com/bandada-infra/bandada",
     "homepage": "https://github.com/bandada-infra/bandada/tree/main/libs/utils",
     "bugs": {
-        "url": "https://github.com/bandada-infra/bandada.git/issues"
+        "url": "https://github.com/bandada-infra/bandada/issues"
     },
     "scripts": {
         "build:watch": "rollup -c rollup.config.ts -w --configPlugin typescript",


### PR DESCRIPTION
## Description

The `bugs.url` field in the JSON configuration contains an unnecessary `.git` in the URL.
This has been corrected to point to the proper issues page:  
```json
"bugs": {
    "url": "https://github.com/bandada-infra/bandada/issues"
}
```  

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Checklist

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
