### PR TITLE
fix: fix incorrect React import from in vite.config.ts

### DIFF
--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -1,8 +1,8 @@
-import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
-import { nodePolyfills } from "vite-plugin-node-polyfills"
+import { react } from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
-    plugins: [nodePolyfills(), react()]
-}))
+    plugins: [nodePolyfills(), react()],
+}));


### PR DESCRIPTION
## Description

Noticed a small mistake in the import from `@vitejs/plugin-react`. It should be a named import rather than a default one. This change fixes that.

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Checklist

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
