### PR TITLE
feat(typeorm): allow overriding tables schema

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,3 +1,6 @@
+# in case you want to define the bandada tables in a specific schema
+# default is unspecified is public schema
+DB_SCHEMA=
 DB_TYPE=sqlite
 DB_URL=data/bandada.db
 API_URL=http://localhost:3000
@@ -23,7 +26,7 @@ TWITTER_REDIRECT_URI=
 TWITTER_CLIENT_ID=
 TWITTER_CLIENT_SECRET=
 
-# The network name must be the same as the id that appears in the `blockchainCredentialSupportedNetworks` list 
+# The network name must be the same as the id that appears in the `blockchainCredentialSupportedNetworks` list
 # exported from the `@bandada/utils` package but with capital letters. E.g. polygon_amoy would be POLYGON_AMOY.
 
 SEPOLIA_RPC_URL=

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -15,6 +15,17 @@ import { CredentialsModule } from "./credentials/credentials.module"
 
 type DB_TYPE = "mysql" | "sqlite" | "postgres"
 
+const TYPEORM_OPTIONS = {
+    autoLoadEntities: true,
+    synchronize: process.env.NODE_ENV !== "production",
+    type: (process.env.DB_TYPE as DB_TYPE) || "postgres",
+    url: process.env.DB_URL,
+    ...(process.env.DB_TYPE === "sqlite" && { database: process.env.DB_URL })
+}
+const schema = process.env.DB_SCHEMA?.trim() || ""
+const typeOrmOptions =
+    schema === "" ? TYPEORM_OPTIONS : { ...TYPEORM_OPTIONS, schema }
+
 @Module({
     imports: [
         AuthModule,
@@ -26,15 +37,7 @@ type DB_TYPE = "mysql" | "sqlite" | "postgres"
             ttl: 60,
             limit: 10
         }),
-        TypeOrmModule.forRoot({
-            type: (process.env.DB_TYPE as DB_TYPE) || "postgres",
-            url: process.env.DB_URL,
-            ...(process.env.DB_TYPE === "sqlite" && {
-                database: process.env.DB_URL
-            }),
-            autoLoadEntities: true,
-            synchronize: process.env.NODE_ENV !== "production"
-        })
+        TypeOrmModule.forRoot(typeOrmOptions)
     ]
 })
 export class AppModule {}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
When integrating bandada in another project, bandada table names may clash with other existing tables (especially the `groups` table).  
One way to elegantly solve such a table name clash issue is to scope tables by schema.  
However by doing this, `typeorm` won't find the table anymore because it isn't set to use a specific schema and default to `public`.
This PR adds an override by env var to set the schema in which all the tables used by the api will be defined.
(e.g [`schema`](https://github.com/typeorm/typeorm/blob/79960e136dc17c8f0e5d3a049e078dbe94b7c68c/src/driver/postgres/PostgresConnectionOptions.ts#L19) option for typeorm postgres driver).

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Other options I have considered:
- rename my own tables
  Will require renaming lot of things in my source code because the model names/modules will change. Moreover other people may integrate bandada with another "vendor" project and may not be able at all to rename things.
- use a separate DB for bandada
  Means more overhead. More resources to host that new DB. New DB settings and secrets to manage etc...

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.
