### PR TITLE
chore(docker): set `api.environment.DB_URL`

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,5 +1,5 @@
-DB_TYPE=sqlite
-DB_URL=data/bandada.db
+DB_TYPE=postgres
+DB_URL=postgres://root:helloworld@localhost:5432/bandada
 API_URL=http://localhost:3000
 DASHBOARD_URL=http://localhost:3001
 ETHEREUM_NETWORK=localhost
@@ -23,7 +23,7 @@ TWITTER_REDIRECT_URI=
 TWITTER_CLIENT_ID=
 TWITTER_CLIENT_SECRET=
 
-# The network name must be the same as the id that appears in the `blockchainCredentialSupportedNetworks` list 
+# The network name must be the same as the id that appears in the `blockchainCredentialSupportedNetworks` list
 # exported from the `@bandada/utils` package but with capital letters. E.g. polygon_amoy would be POLYGON_AMOY.
 
 SEPOLIA_RPC_URL=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
             dockerfile: ./apps/api/Dockerfile
         image: bandada-api:latest
         restart: unless-stopped
+        environment:
+            DB_URL: postgres://root:helloworld@postgres:5432/bandada
         env_file:
             - apps/api/.env
         ports:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Docker is the most convenient way to get started. As the docker compose files already define a postgres service with migrations  applied.  
However the environment variables are set with an `env_file` and the `.env.example` uses sqlite. Which is confusing.  
As a dev:
- I don;t want to have to deal with DB setup and seeding: that's good you provide a postgres service in docker compose
- I may run the api with the docker service OR with `yarn dev` (because i am making changes and don;t want to rebuild the image every time)

Depending on the situation the postgres url will be different (different host: `postgres` or `localhost`).  
To accomodate for both situations, one needs either to use different `.env` files (e.g `.env.local` and `.env.docker`).  
Or one can override the `env_file` by setting `environment.DB_URL` in docker compose.  
This PR does the latter.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Checklist

<!-- Please check if the PR fulfills these requirements. -->

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have run `yarn prettier` and `yarn lint` without getting any errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.
