### PR TITLE
fix: fix Incorrect .addOptionalParam Usage with <boolean> in Hardhat …

### DIFF
--- a/apps/contracts/tasks/deploy-bandada-semaphore.ts
+++ b/apps/contracts/tasks/deploy-bandada-semaphore.ts
@@ -2,7 +2,7 @@ import { Contract } from "ethers"
 import { task, types } from "hardhat/config"
 
 task("deploy:bandada-semaphore", "Deploy a BandadaSemaphore contract")
-    .addOptionalParam<boolean>("logs", "Print the logs", true, types.boolean)
+    .addOptionalParam("logs", "Print the logs", true, types.boolean)
     .addOptionalParam(
         "bandada",
         "Bandada contract address",


### PR DESCRIPTION
## Description  
I’ve fixed an issue where the `.addOptionalParam` method in the Hardhat configuration was incorrectly using a generic `<boolean>`. Now, the type for the parameter is specified separately using `types.boolean`, as per the correct Hardhat configuration syntax.

## Related Issue  
N/A

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

## Other information  
N/A

## Checklist

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn prettier` and `yarn lint` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes